### PR TITLE
Update to MM_Bluedog.cfg and new config for OPT Spaceplane Parts.

### DIFF
--- a/GameData/EngineIgnitor/MM_Configs/MM_Bluedog.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Bluedog.cfg
@@ -1,7 +1,41 @@
 // From forum user @dobrasao
+// Configs for Agena, Atlas "Bossart" engines, Titan LR-87 single-chamber vacuum, 
+// and Saturn F-1A, J-2S, J-2A-2, J-2 Sea Level, and J-2T-250K provided by forum user Nittany Tiger.
 
 //BLUEDOG MOD===========================================BALANCING COMPLETE BASED ON PROBABLE ENGINE ROLE
 ///////////////////////////////////////////////////////////////////
+
+//===AGENA SECTION==================================
+//bluedog agena A - Belle-A-25 "Hadar"
+@PART[bluedog_AgenaA]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3
+		AutoIgnitionTemperature = 500
+		IgnitorType = I-3
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//bluedog agena D - Belle-D-35 "Mafuni"
+@PART[bluedog_AgenaD]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 15
+		AutoIgnitionTemperature = 500
+		IgnitorType = I-5
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+//===END OF AGENA SECTION===
 
 //===APOLLO SECTION=================================
 //bluedog lem descent - sina mem dps
@@ -111,6 +145,37 @@
 	}
 }
 
+//New bluedog atlasVernier- Bossart-1E-101 - Crow Radial
+@PART[bluedog_Atlas_LR101_Radial]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 32
+		AutoIgnitionTemperature = 430
+		IgnitorType = I-1
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//bluedog atlast booster (LR-89) - Bossart-1E-89 - Buzzard 
+@PART[bluedog_Atlas_LR89]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		IgnitorType = I-1
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+
 //bluedog atlasV RD180 - Muo 2207
 @PART[bluedog_AtlasV_RD180]
 {
@@ -128,6 +193,21 @@
 
 //bluedog atlasV Sustainer - Muo 2207
 @PART[bluedog_atlasSustainer]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 12
+		AutoIgnitionTemperature = 800
+		IgnitorType = I-4
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//New bluedog atlasV Sustainer - Bossart-1E-105 - Vulture
+@PART[bluedog_Atlas_LR105]
 {
 	MODULE
 	{
@@ -395,6 +475,21 @@
 	}
 }
 
+//bluedog f1a - Sarnus-LE1F-2214A "Regor A"
+@PART[bluedog_F1A]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3
+		AutoIgnitionTemperature = 650
+		IgnitorType = I-10
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
 //bluedog h1c - Sarnus-HC1-280 "Grivan"
 @PART[bluedog_H1C]
 {
@@ -440,7 +535,52 @@
 	}
 }
 
-//bluedog j2 toroidal - Sarnus-HE2JT-200K "Tohces"
+//bluedog j2s - Sarnus-HE2J-570-S "Dnoces S"
+@PART[bluedog_J2S]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3
+		AutoIgnitionTemperature = 650
+		IgnitorType = I-6
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//bluedog j2-A2 - Sarnus-HE2J-580-A2 "Dnoces A-2"
+@PART[bluedog_J2A2]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3
+		AutoIgnitionTemperature = 650
+		IgnitorType = I-6
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//bluedog j2 sea level - Sarnus-HESL2J-475 "Dnoces Sea Level"
+@PART[bluedog_J2sl]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3
+		AutoIgnitionTemperature = 650
+		IgnitorType = I-6
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//bluedog j2-t-200k toroidal - Sarnus-HE2JT-200K "Tohces"
 @PART[bluedog_J2_Toroidal]
 {
 	MODULE
@@ -454,6 +594,22 @@
 		
 	}
 }
+
+//bluedog j2-t-250k toroidal - Sarnus-HE2JT-250K "Tohces-P"
+@PART[bluedog_J2_Toroidal250K]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3
+		AutoIgnitionTemperature = 650
+		IgnitorType = I-3
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
 //===END OF SATURN SECTION===
 
 //===TITAN SECTION===========================
@@ -519,6 +675,21 @@
 
 //bluedog lr87 single chamber - Prometheus-X-250 "Perseus"
 @PART[bluedog_LR87_SingleChamber]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 6
+		AutoIgnitionTemperature = 650
+		IgnitorType = I-3
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.2
+		
+	}
+}
+
+//bluedog lr87 single chamber vacuum - Prometheus-X-250-V "Perseus"
+@PART[bluedog_LR87_SingleChamberVac]
 {
 	MODULE
 	{

--- a/GameData/EngineIgnitor/MM_Configs/MM_OPT.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_OPT.cfg
@@ -1,0 +1,32 @@
+//Engine Igniter OPT Spaceplane Parts Config
+//By Nittany Tiger
+
+//OPT-E J Linear Aerospike
+@PART[j_linear_aerospike]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 5
+        AutoIgnitionTemperature = 500
+        IgnitorType = Internal I-5
+	    UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 5
+    }
+}
+
+//OPT-E SCOOP Rocket "ARI-75b"
+@PART[AAengine]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 10
+        AutoIgnitionTemperature = 500
+        IgnitorType = Internal I-20
+	    UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 20
+    }
+}


### PR DESCRIPTION
Update to Bluedog Design Bureau config to add missing configs for most LF/O engines and new config for OPT Spaceplane Parts rocket engines.