### PR TITLE
New patches for CryoEngines 1.0 onwards

### DIFF
--- a/GameData/EngineIgnitor/MM_Configs/MM_Cryoengines.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Cryoengines.cfg
@@ -1,3 +1,117 @@
+//CryoEngines 1.0 onwards
+//By Zorg
+//Ignitions based on real world limits, using RO configs as main reference
+
+@PART[cryoengine-stromboli-1]//RL10-A5 sea level RL10 engine. Capable of multi starts as used on DC-X vertical landing demonstrator.
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 10
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+
+	}
+}
+
+@PART[cryoengine-hecate-1]//RL-10C-2
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 10
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[cryoengine-vesuvius-1]//Vulcain 2 (Ariane 5 core)
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[cryoengine-pavonis-1]//RL-60 (Proposed RL10 successor)
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 45
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[cryoengine-erebus-1]//RD-0120 (Energia core engines)
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[cryoengine-fuji-1]//LE-9 (H3 first stage)
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[cryoengine-ulysses-1]//J-2X (constellation)
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 8
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[cryoengine-etna-1]//RS-68A (Delta IV)
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[cryoengine-tharsis-1]//RL-60 cluster
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 45
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+///OLD DEPCREDATED ENGINES from before CryoEngines 1.0////
 // From forum user @dobrasao
 
 //CRYOENGINES MOD===========================================BALANCING COMPLETE BASED ON PROBABLE ENGINE ROLE
@@ -13,7 +127,7 @@
 		IgnitorType = I-4
 		UseUllageSimulation = false
 		ChanceWhenUnstable = 0.2
-		
+
 	}
 }
 
@@ -28,7 +142,7 @@
 		IgnitorType = I-4
 		UseUllageSimulation = false
 		ChanceWhenUnstable = 0.2
-		
+
 	}
 }
 
@@ -43,7 +157,7 @@
 		IgnitorType = I-2
 		UseUllageSimulation = false
 		ChanceWhenUnstable = 0.3
-		
+
 	}
 }
 
@@ -58,7 +172,7 @@
 		IgnitorType = I-2
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.4
-		
+
 	}
 }
 
@@ -73,7 +187,7 @@
 		IgnitorType = I-1
 		UseUllageSimulation = false
 		ChanceWhenUnstable = 0.3
-		
+
 	}
 }
 
@@ -88,9 +202,8 @@
 		IgnitorType = I-1
 		UseUllageSimulation = false
 		ChanceWhenUnstable = 0.3
-		
+
 	}
 }
 ///////////////////////////////////////////////////////////////////
 //END OF CRYOENGINES MOD====================================
-


### PR DESCRIPTION
Patches for new cryoengines added in 1.0

Uses realistic ullage requirements and ignitions.

Uses RO configs as main reference.