### PR TITLE
Add support for Knes, CryoEngines, NFLV, Restock plus, ReDirect and more.

### DIFF
--- a/GameData/EngineIgnitor/MM_Configs/ALL_INTERNAL.cfg.disabled
+++ b/GameData/EngineIgnitor/MM_Configs/ALL_INTERNAL.cfg.disabled
@@ -1,0 +1,11 @@
+// Optional patch to make all engines that require external ignitions use internal. Useful if you want to air start sea level engines.
+// To use, Change the file extension from .cfg.disabled to just .cfg . Suggest placing into a personal patches folder so its not overwritten each time Engine Ignitor updates.
+// By Zorg
+@PART[*]:HAS[@MODULE[ModuleEngineIgnitor]]:LAST
+{
+  @MODULE[ModuleEngineIgnitor]:HAS[#IgnitionsAvailable[0]]
+  {
+    @IgnitionsAvailable = 1
+    %IgnitorType = Internal
+  }
+}

--- a/GameData/EngineIgnitor/MM_Configs/ALL_INTERNAL.cfg.disabled
+++ b/GameData/EngineIgnitor/MM_Configs/ALL_INTERNAL.cfg.disabled
@@ -9,3 +9,8 @@
     %IgnitorType = Internal
   }
 }
+
+@PART[*]:HAS[@MODULE[ModuleExternalIgnitor]]:LAST
+{
+  !MODULE[ModuleExternalIgnitor]
+}

--- a/GameData/EngineIgnitor/MM_Configs/MM_BahaSP_TechUpgrades.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_BahaSP_TechUpgrades.cfg
@@ -2,7 +2,7 @@
 
 
 // Ignitor upgrade 2 - tier 5
-@PART[bahaSRadialEngine]:FINAL
+@PART[bahaSRadialEngine]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -18,7 +18,7 @@
         }
     }
 }
-@PART[bahaRetractEngine]:FINAL
+@PART[bahaRetractEngine]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -37,7 +37,7 @@
 
 
 // Ignitor upgrade 4 - tier 7
-@PART[bahaTrrEngine]:FINAL
+@PART[bahaTrrEngine]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -56,7 +56,7 @@
 
 
 // Ignitor upgrade 8 - tier 8
-@PART[critterCrawler]:FINAL
+@PART[critterCrawler]
 {
     @MODULE[ModuleEngineIgnitor]
     {        

--- a/GameData/EngineIgnitor/MM_Configs/MM_CommunityPatchClamps.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_CommunityPatchClamps.cfg
@@ -2,7 +2,7 @@
 // which conflicts with ModuleManager, you replace the brackets with 
 // questionmarks instead.
 
-@PART[?launchClamp2?]:FINAL
+@PART[?launchClamp2?]
 {
     MODULE
     {
@@ -12,7 +12,7 @@
         provideRequiredResources = true
     }
 }
-@PART[?launchClamp0?]:FINAL
+@PART[?launchClamp0?]
 {
     MODULE
     {
@@ -22,7 +22,7 @@
         provideRequiredResources = true
     }
 }
-@PART[?launchClamp3?]:FINAL
+@PART[?launchClamp3?]
 {
     MODULE
     {

--- a/GameData/EngineIgnitor/MM_Configs/MM_Cryoengines.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Cryoengines.cfg
@@ -1,3 +1,117 @@
+//CryoEngines 1.0 onwards
+//By Zorg
+//Ignitions based on real world limits, using RO configs as main reference
+
+@PART[cryoengine-stromboli-1]//RL10-A5 sea level RL10 engine. Capable of multi starts as used on DC-X vertical landing demonstrator.
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 10
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+
+	}
+}
+
+@PART[cryoengine-hecate-1]//RL-10C-2
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 10
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[cryoengine-vesuvius-1]//Vulcain 2 (Ariane 5 core)
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[cryoengine-pavonis-1]//RL-60 (Proposed RL10 successor)
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 45
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[cryoengine-erebus-1]//RD-0120 (Energia core engines)
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[cryoengine-fuji-1]//LE-9 (H3 first stage)
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[cryoengine-ulysses-1]//J-2X (constellation)
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 8
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[cryoengine-etna-1]//RS-68A (Delta IV)
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[cryoengine-tharsis-1]//RL-60 cluster
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 45
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+///OLD DEPCREDATED ENGINES from before CryoEngines 1.0////
 // From forum user @dobrasao
 
 //CRYOENGINES MOD===========================================BALANCING COMPLETE BASED ON PROBABLE ENGINE ROLE
@@ -13,7 +127,7 @@
 		IgnitorType = I-4
 		UseUllageSimulation = false
 		ChanceWhenUnstable = 0.2
-		
+
 	}
 }
 
@@ -28,7 +142,7 @@
 		IgnitorType = I-4
 		UseUllageSimulation = false
 		ChanceWhenUnstable = 0.2
-		
+
 	}
 }
 
@@ -43,7 +157,7 @@
 		IgnitorType = I-2
 		UseUllageSimulation = false
 		ChanceWhenUnstable = 0.3
-		
+
 	}
 }
 
@@ -58,7 +172,7 @@
 		IgnitorType = I-2
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.4
-		
+
 	}
 }
 
@@ -73,7 +187,7 @@
 		IgnitorType = I-1
 		UseUllageSimulation = false
 		ChanceWhenUnstable = 0.3
-		
+
 	}
 }
 
@@ -88,9 +202,8 @@
 		IgnitorType = I-1
 		UseUllageSimulation = false
 		ChanceWhenUnstable = 0.3
-		
+
 	}
 }
 ///////////////////////////////////////////////////////////////////
 //END OF CRYOENGINES MOD====================================
-

--- a/GameData/EngineIgnitor/MM_Configs/MM_Cryoengines.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Cryoengines.cfg
@@ -2,7 +2,7 @@
 //By Zorg
 //Ignitions based on real world limits, using RO configs as main reference
 
-@PART[cryoengine-stromboli-1]//RL10-A5 sea level RL10 engine. Capable of multi starts as used on DC-X vertical landing demonstrator.
+@PART[cryoengine-stromboli-1]:NEEDS[CryoEngines]//RL10-A5 sea level RL10 engine. Capable of multi starts as used on DC-X vertical landing demonstrator.
 {
 	MODULE
 	{
@@ -15,7 +15,7 @@
 	}
 }
 
-@PART[cryoengine-hecate-1]//RL-10C-2
+@PART[cryoengine-hecate-1]:NEEDS[CryoEngines]//RL-10C-2
 {
 	MODULE
 	{
@@ -28,7 +28,7 @@
 	}
 }
 
-@PART[cryoengine-vesuvius-1]//Vulcain 2 (Ariane 5 core)
+@PART[cryoengine-vesuvius-1]:NEEDS[CryoEngines]//Vulcain 2 (Ariane 5 core)
 {
 	MODULE
 	{
@@ -41,7 +41,7 @@
 	}
 }
 
-@PART[cryoengine-pavonis-1]//RL-60 (Proposed RL10 successor)
+@PART[cryoengine-pavonis-1]:NEEDS[CryoEngines]//RL-60 (Proposed RL10 successor)
 {
 	MODULE
 	{
@@ -54,7 +54,7 @@
 	}
 }
 
-@PART[cryoengine-erebus-1]//RD-0120 (Energia core engines)
+@PART[cryoengine-erebus-1]:NEEDS[CryoEngines]//RD-0120 (Energia core engines)
 {
 	MODULE
 	{
@@ -68,7 +68,7 @@
 	}
 }
 
-@PART[cryoengine-fuji-1]//LE-9 (H3 first stage)
+@PART[cryoengine-fuji-1]:NEEDS[CryoEngines]//LE-9 (H3 first stage)
 {
 	MODULE
 	{
@@ -82,7 +82,7 @@
 	}
 }
 
-@PART[cryoengine-ulysses-1]//J-2X (constellation)
+@PART[cryoengine-ulysses-1]:NEEDS[CryoEngines]//J-2X (constellation)
 {
 	MODULE
 	{
@@ -95,7 +95,7 @@
 	}
 }
 
-@PART[cryoengine-etna-1]//RS-68A (Delta IV)
+@PART[cryoengine-etna-1]:NEEDS[CryoEngines]//RS-68A (Delta IV)
 {
 	MODULE
 	{
@@ -109,7 +109,7 @@
 	}
 }
 
-@PART[cryoengine-tharsis-1]//RL-60 cluster
+@PART[cryoengine-tharsis-1]:NEEDS[CryoEngines]//RL-60 cluster
 {
 	MODULE
 	{
@@ -121,105 +121,3 @@
 		ECforIgnition = 30
 	}
 }
-
-///OLD DEPCREDATED ENGINES from before CryoEngines 1.0//////////////////////////////////////////
-
-//------------------------------------------------------//
-
-
-
-// From forum user @dobrasao
-
-//CRYOENGINES MOD===========================================BALANCING COMPLETE BASED ON PROBABLE ENGINE ROLE
-///////////////////////////////////////////////////////////////////
-//cryoengine-25-1 ----CT2X Tunguska
-@PART[cryoengine-25-1]
-{
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 7
-		AutoIgnitionTemperature = 800
-		IgnitorType = I-4
-		UseUllageSimulation = false
-		ChanceWhenUnstable = 0.2
-
-	}
-}
-
-//cryoengine-25-2 ----KS01 Odin
-@PART[cryoengine-25-2]
-{
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 7
-		AutoIgnitionTemperature = 800
-		IgnitorType = I-4
-		UseUllageSimulation = false
-		ChanceWhenUnstable = 0.2
-
-	}
-}
-
-//cryoengine-125-1 ----VL-1 Volcano
-@PART[cryoengine-125-1]
-{
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 12
-		AutoIgnitionTemperature = 400
-		IgnitorType = I-2
-		UseUllageSimulation = false
-		ChanceWhenUnstable = 0.3
-
-	}
-}
-
-//cryoengine-125-2 ----CT10 Chelyabinsk
-@PART[cryoengine-125-2]
-{
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 20
-		AutoIgnitionTemperature = 800
-		IgnitorType = I-2
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.4
-
-	}
-}
-
-//cryoengine-375-1 ----KS-68 Mars
-@PART[cryoengine-375-1]
-{
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 12
-		AutoIgnitionTemperature = 400
-		IgnitorType = I-1
-		UseUllageSimulation = false
-		ChanceWhenUnstable = 0.3
-
-	}
-}
-
-//cryoengine-375-2 ----CT65 Yucatan
-@PART[cryoengine-375-2]
-{
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 20
-		AutoIgnitionTemperature = 380
-		IgnitorType = I-1
-		UseUllageSimulation = false
-		ChanceWhenUnstable = 0.3
-
-	}
-}
-///////////////////////////////////////////////////////////////////
-//END OF CRYOENGINES MOD====================================

--- a/GameData/EngineIgnitor/MM_Configs/MM_Cryoengines.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Cryoengines.cfg
@@ -31,7 +31,7 @@
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 1
+		IgnitionsAvailable = 1 //Allow for use as upper stage of Liberty rocket
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
@@ -55,7 +55,8 @@
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 1
+		IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
@@ -67,7 +68,8 @@
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 1
+		IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
@@ -91,7 +93,8 @@
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 1
+		IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2

--- a/GameData/EngineIgnitor/MM_Configs/MM_Cryoengines.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Cryoengines.cfg
@@ -11,6 +11,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 10
 	}
 }
 
@@ -23,6 +24,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 20
 	}
 }
 
@@ -35,6 +37,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 30
 	}
 }
 
@@ -47,6 +50,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 20
 	}
 }
 
@@ -60,6 +64,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 30
 	}
 }
 
@@ -73,6 +78,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 30
 	}
 }
 
@@ -85,6 +91,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 20
 	}
 }
 
@@ -98,6 +105,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 50
 	}
 }
 
@@ -110,10 +118,16 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 30
 	}
 }
 
-///OLD DEPCREDATED ENGINES from before CryoEngines 1.0////
+///OLD DEPCREDATED ENGINES from before CryoEngines 1.0//////////////////////////////////////////
+
+//------------------------------------------------------//
+
+
+
 // From forum user @dobrasao
 
 //CRYOENGINES MOD===========================================BALANCING COMPLETE BASED ON PROBABLE ENGINE ROLE

--- a/GameData/EngineIgnitor/MM_Configs/MM_Cryoengines.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Cryoengines.cfg
@@ -11,7 +11,6 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-
 	}
 }
 

--- a/GameData/EngineIgnitor/MM_Configs/MM_EngineIgnitor.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_EngineIgnitor.cfg
@@ -27,7 +27,7 @@
     }
 }
 
-@PART[kerbalEVA]:FINAL
+@PART[kerbalEVA]
 {
     MODULE
     {
@@ -42,7 +42,7 @@
     }
 
 }
-@PART[kerbalEVAfemale]:FINAL
+@PART[kerbalEVAfemale]
 {
     MODULE
     {
@@ -57,7 +57,7 @@
     }
 
 }
-@PART[kerbalEVAVintage]:FINAL
+@PART[kerbalEVAVintage]
 {
     MODULE
     {
@@ -72,7 +72,7 @@
     }
 
 }
-@PART[kerbalEVAfemaleVintage]:FINAL
+@PART[kerbalEVAfemaleVintage]
 {
     MODULE
     {

--- a/GameData/EngineIgnitor/MM_Configs/MM_FASA_Clamps.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_FASA_Clamps.cfg
@@ -1,41 +1,41 @@
 
-@PART[FASAlaunchClampAtlas]:FINAL
+@PART[FASAlaunchClampAtlas]
 {
     MODULE
     {
         name = ModuleExternalIgnitor
         IgnitorType = External
-        IgniteRange = 3.0
+        IgniteRange = 10.0
         provideRequiredResources = true
     }
 }
-@PART[FASAlaunchClampApollo]:FINAL
+@PART[FASAlaunchClampApollo]
 {
     MODULE
     {
         name = ModuleExternalIgnitor
         IgnitorType = External
-        IgniteRange = 3.0
+        IgniteRange = 10.0
         provideRequiredResources = true
     }
 }
-@PART[FASAlaunchClamp125]:FINAL
+@PART[FASAlaunchClamp125]
 {
     MODULE
     {
         name = ModuleExternalIgnitor
         IgnitorType = External
-        IgniteRange = 3.0
+        IgniteRange = 10.0
         provideRequiredResources = true
     }
 }
-@PART[FASAlaunchClamp25]:FINAL
+@PART[FASAlaunchClamp25]
 {
     MODULE
     {
         name = ModuleExternalIgnitor
         IgnitorType = External
-        IgniteRange = 3.0
+        IgniteRange = 10.0
         provideRequiredResources = true
     }
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_Fuji.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Fuji.cfg
@@ -1,0 +1,18 @@
+//Config for Fuji
+// By Zorg
+// Not much data on the engine. But a highly restarable engine is expected for a modern crewed OMS engine.
+
+
+
+@PART[Polaris_Engine_A]:NEEDS[Fuji]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 45
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+		ECforIgnition = 10
+	}
+}

--- a/GameData/EngineIgnitor/MM_Configs/MM_HGR_TechUpgrades.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_HGR_TechUpgrades.cfg
@@ -1,7 +1,7 @@
 
 
 // Ignitor upgrade 2 - tier 5
-@PART[FG120]:FINAL
+@PART[FG120]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -22,7 +22,7 @@
 }
 
 // Ignitor upgrade 2 - tier 5
-@PART[HGRG47b]:FINAL
+@PART[HGRG47b]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -40,7 +40,7 @@
 }
 
 // Ignitor upgrade 2 - tier 5
-@PART[HGR_FG90_Engine]:FINAL
+@PART[HGR_FG90_Engine]
 {
     @MODULE[ModuleEngineIgnitor]
     {        

--- a/GameData/EngineIgnitor/MM_Configs/MM_KerbalAtomics.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_KerbalAtomics.cfg
@@ -9,7 +9,7 @@
         IgnitionsAvailable = 45
         AutoIgnitionTemperature = 500
         IgnitorType = Nuclear E-5
-	    UseUllageSimulation = false
+	    UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2  //0-1
 		ECforIgnition = 5
     }

--- a/GameData/EngineIgnitor/MM_Configs/MM_KerbalAtomics.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_KerbalAtomics.cfg
@@ -1,7 +1,7 @@
 //Kerbal Atomics Engine Ignitor Configs
 
 //NV-10 "Eel"
-@PART[ntr-sc-0625-1]
+@PART[ntr-sc-0625-1]:NEEDS[KerbalAtomics]
 {
     MODULE
     {
@@ -16,7 +16,7 @@
 }
 
 //NV-50 "Stubber"
-@PART[ntr-sc-125-2]
+@PART[ntr-sc-125-2]:NEEDS[KerbalAtomics]
 {
     MODULE
     {
@@ -32,7 +32,7 @@
 }
 
 //NV-100 "Neptune"
-@PART[ntr-sc-125-1]
+@PART[ntr-sc-125-1]:NEEDS[KerbalAtomics]
 {
     MODULE
     {
@@ -48,7 +48,7 @@
 }
 
 //NV-500 "Poseidon"
-@PART[ntr-sc-25-1]
+@PART[ntr-sc-25-1]:NEEDS[KerbalAtomics]
 {
     MODULE
     {
@@ -64,7 +64,7 @@
 }
 
 //NV-GE "Liberator"
-@PART[ntr-gc-25-1]
+@PART[ntr-gc-25-1]:NEEDS[KerbalAtomics]
 {
     MODULE
     {
@@ -79,7 +79,7 @@
 }
 
 //NV-GX "Emancipator"
-@PART[ntr-gc-25-2]
+@PART[ntr-gc-25-2]:NEEDS[KerbalAtomics]
 {
     MODULE
     {
@@ -94,7 +94,7 @@
 }
 
 //NV-GL "Deliverance"
-@PART[ntr-gc-25-3]
+@PART[ntr-gc-25-3]:NEEDS[KerbalAtomics]
 {
     MODULE
     {
@@ -109,7 +109,7 @@
 }
 
 //NV-DC "Scylla"
-@PART[ntr-sc-375-1]
+@PART[ntr-sc-375-1]:NEEDS[KerbalAtomics]
 {
     MODULE
     {
@@ -126,10 +126,11 @@
 
 //Change to LV-N to enable ullage
 
-@PART[nuclearEngine]:AFTER[EngineIgnitor]
+@PART[nuclearEngine]:NEEDS[KerbalAtomics]:AFTER[EngineIgnitor]
 {
 	@MODULE[ModuleEngineIgnitor]
 	{
-		@UseUllageSimulation = true
+		%UseUllageSimulation = true
+    %DontUseIgnitorIfMultiModeOn = true
 	}
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_KerbalAtomics.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_KerbalAtomics.cfg
@@ -124,7 +124,7 @@
     }
 }
 
-//Change to LV-N to enable ullage
+//Change to LV-N to enable ullage handle KA multimode switch.
 
 @PART[nuclearEngine]:NEEDS[KerbalAtomics]:AFTER[EngineIgnitor]
 {

--- a/GameData/EngineIgnitor/MM_Configs/MM_Knes.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Knes.cfg
@@ -11,6 +11,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 50
 	}
 }
 
@@ -23,6 +24,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 30
 	}
 }
 
@@ -36,6 +38,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 30
 	}
 }
 
@@ -49,6 +52,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 30
 	}
 }
 
@@ -61,6 +65,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 30
 	}
 }
 
@@ -73,6 +78,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 10
 	}
 }
 
@@ -85,6 +91,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 5
 	}
 }
 
@@ -97,6 +104,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 15
 	}
 }
 
@@ -110,6 +118,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 50
 	}
 }
 
@@ -123,6 +132,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 50
 	}
 }
 
@@ -136,6 +146,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 50
 	}
 }
 
@@ -148,6 +159,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 50
 	}
 }
 
@@ -160,6 +172,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 20
 	}
 }
 
@@ -173,6 +186,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 15
 	}
 }
 
@@ -185,6 +199,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 20
 	}
 }
 
@@ -198,6 +213,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 20
 	}
 }
 
@@ -211,6 +227,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 10
 	}
 }
 
@@ -223,6 +240,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 10
 	}
 }
 
@@ -235,6 +253,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 50
 	}
 }
 
@@ -247,5 +266,6 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+		ECforIgnition = 20
 	}
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_Knes.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Knes.cfg
@@ -1,0 +1,251 @@
+//By Zorg
+//Ignitions based on real world limits, using RO configs as main reference. Educated guess where info not available.
+
+@PART[_Knes_Catherine_Stage_1875]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_Cora_Engine_1]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_Cora_Engine_SL]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_Diamant_Engine_09375]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_Diane_Engine_125]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_H2_Engine_09375]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3 //guess
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_H3_Engine_0625]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3 //guess
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_L3S_L3S_HM4_Engine]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_L3S_L140]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_L3S_L220]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_L3S_L220N]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_L3S_L33_Engine]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_L3S_L3S_HM60_Engine]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_L3S_PAL]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_Mireille_Engine_09375]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_Veronique_Engine_03125]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[_Knes_Vesta_Engine_0625]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[Knes_Engine_EPS]//Aestus engine for Ariane 5 upper stage
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 20
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[Knes_Engine_Vulcain]//Aestus engine for Ariane 5 upper stage
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 1 //Internal ignition to allow for use as upper stage of Liberty rocket
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[Knes_Engine_Zebulon]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}

--- a/GameData/EngineIgnitor/MM_Configs/MM_Knes.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Knes.cfg
@@ -1,7 +1,7 @@
 //By Zorg
 //Ignitions based on real world limits, using RO configs as main reference. Educated guess where info not available.
 
-@PART[_Knes_Catherine_Stage_1875]//
+@PART[_Knes_Catherine_Stage_1875]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -15,7 +15,7 @@
 	}
 }
 
-@PART[_Knes_Cora_Engine_1]//
+@PART[_Knes_Cora_Engine_1]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -28,7 +28,7 @@
 	}
 }
 
-@PART[_Knes_Cora_Engine_SL]//
+@PART[_Knes_Cora_Engine_SL]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -42,7 +42,7 @@
 	}
 }
 
-@PART[_Knes_Diamant_Engine_09375]//
+@PART[_Knes_Diamant_Engine_09375]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -56,7 +56,7 @@
 	}
 }
 
-@PART[_Knes_Diane_Engine_125]//
+@PART[_Knes_Diane_Engine_125]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -69,12 +69,12 @@
 	}
 }
 
-@PART[_Knes_H2_Engine_09375]//
+@PART[_Knes_H2_Engine_09375]:NEEDS[Knes]//
 {
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 3 //guess
+		IgnitionsAvailable = 3 :NEEDS[Knes]//guess
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
@@ -82,12 +82,12 @@
 	}
 }
 
-@PART[_Knes_H3_Engine_0625]//
+@PART[_Knes_H3_Engine_0625]:NEEDS[Knes]//
 {
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 3 //guess
+		IgnitionsAvailable = 3 :NEEDS[Knes]//guess
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
@@ -95,7 +95,7 @@
 	}
 }
 
-@PART[_Knes_L3S_L3S_HM4_Engine]//
+@PART[_Knes_L3S_L3S_HM4_Engine]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -108,7 +108,7 @@
 	}
 }
 
-@PART[_Knes_L3S_L140]//
+@PART[_Knes_L3S_L140]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -122,7 +122,7 @@
 	}
 }
 
-@PART[_Knes_L3S_L220]//
+@PART[_Knes_L3S_L220]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -136,7 +136,7 @@
 	}
 }
 
-@PART[_Knes_L3S_L220N]//
+@PART[_Knes_L3S_L220N]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -150,7 +150,7 @@
 	}
 }
 
-@PART[_Knes_L3S_L33_Engine]//
+@PART[_Knes_L3S_L33_Engine]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -163,7 +163,7 @@
 	}
 }
 
-@PART[_Knes_L3S_L3S_HM60_Engine]//
+@PART[_Knes_L3S_L3S_HM60_Engine]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -176,7 +176,7 @@
 	}
 }
 
-@PART[_Knes_L3S_PAL]//
+@PART[_Knes_L3S_PAL]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -190,7 +190,7 @@
 	}
 }
 
-@PART[_Knes_Mireille_Engine_09375]//
+@PART[_Knes_Mireille_Engine_09375]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -203,7 +203,7 @@
 	}
 }
 
-@PART[_Knes_Veronique_Engine_03125]//
+@PART[_Knes_Veronique_Engine_03125]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -217,7 +217,7 @@
 	}
 }
 
-@PART[_Knes_Vesta_Engine_0625]//
+@PART[_Knes_Vesta_Engine_0625]:NEEDS[Knes]//
 {
 	MODULE
 	{
@@ -231,7 +231,7 @@
 	}
 }
 
-@PART[Knes_Engine_EPS]//Aestus engine for Ariane 5 upper stage
+@PART[Knes_Engine_EPS]:NEEDS[Knes]//Aestus engine for Ariane 5 upper stage
 {
 	MODULE
 	{
@@ -244,12 +244,12 @@
 	}
 }
 
-@PART[Knes_Engine_Vulcain]//Aestus engine for Ariane 5 upper stage
+@PART[Knes_Engine_Vulcain]:NEEDS[Knes]//Aestus engine for Ariane 5 upper stage
 {
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-    IgnitionsAvailable = 1 //Internal ignition to allow for use as upper stage of Liberty rocket
+    IgnitionsAvailable = 1//Internal ignition to allow for use as upper stage of Liberty rocket
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
@@ -257,7 +257,7 @@
 	}
 }
 
-@PART[Knes_Engine_Zebulon]//
+@PART[Knes_Engine_Zebulon]:NEEDS[Knes]//
 {
 	MODULE
 	{

--- a/GameData/EngineIgnitor/MM_Configs/MM_Knes.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Knes.cfg
@@ -52,7 +52,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-		ECforIgnition = 30
+		ECforIgnition = 20
 	}
 }
 
@@ -65,7 +65,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-		ECforIgnition = 30
+		ECforIgnition = 20
 	}
 }
 
@@ -159,7 +159,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-		ECforIgnition = 50
+		ECforIgnition = 30
 	}
 }
 
@@ -199,7 +199,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-		ECforIgnition = 20
+		ECforIgnition = 10
 	}
 }
 
@@ -213,7 +213,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-		ECforIgnition = 20
+		ECforIgnition = 15
 	}
 }
 

--- a/GameData/EngineIgnitor/MM_Configs/MM_MOLE_TechUpgrades.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_MOLE_TechUpgrades.cfg
@@ -1,6 +1,6 @@
 // ======================= Engines Ignition Upgrades =======================
 // Ignitor upgrade 1 - tier 4
-@PART[WBI_Fulcrum]:FINAL
+@PART[WBI_Fulcrum]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -19,7 +19,7 @@
         }
     }
 }
-@PART[WBI_Corvette]:FINAL
+@PART[WBI_Corvette]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -38,7 +38,7 @@
 
 
 // Ignitor upgrade 2 - tier 5
-@PART[WBI_Corvette2]:FINAL
+@PART[WBI_Corvette2]
 {
     @MODULE[ModuleEngineIgnitor]
     {        

--- a/GameData/EngineIgnitor/MM_Configs/MM_Mk25Ex.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Mk25Ex.cfg
@@ -10,7 +10,7 @@
 }
 
 // Ignitor upgrade 4 - tier 7
-@PART[mk25SSME]:FINAL
+@PART[mk25SSME]
 {
     @MODULE[ModuleEngineIgnitor]
     {        

--- a/GameData/EngineIgnitor/MM_Configs/MM_Mk2_TechUpgrades.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Mk2_TechUpgrades.cfg
@@ -1,7 +1,7 @@
 // ======================= Engines Ignition Upgrades =======================
 
 // Ignitor upgrade 3 - tier 7
-@PART[M2X_FuselageRVTOLE]:FINAL
+@PART[M2X_FuselageRVTOLE]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -20,7 +20,7 @@
 
 
 // Ignitor upgrade 4 - tier 7
-@PART[M2X_AugmentedRocket]:FINAL
+@PART[M2X_AugmentedRocket]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -39,7 +39,7 @@
 
 
 // Ignitor upgrade 8 - tier 8
-@PART[M2X_LinearAerospike]:FINAL
+@PART[M2X_LinearAerospike]
 {
     @MODULE[ModuleEngineIgnitor]
     {        

--- a/GameData/EngineIgnitor/MM_Configs/MM_ModularLaunchPads.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_ModularLaunchPads.cfg
@@ -10,3 +10,14 @@
       provideRequiredResources = true
   }
 }
+
+@PART[AM_MLP_ShuttleLauncherBaseFree|AM_MLP_SaturnLauncherMilkstool|AM_MLP_SaturnMobileLauncherBaseFree]:NEEDS[ModularLaunchPads]:AFTER[EngineIgnitor]
+{
+  MODULE
+  {
+      name = ModuleExternalIgnitor
+      IgnitorType = External
+      IgniteRange = 50.0
+      provideRequiredResources = true
+  }
+}

--- a/GameData/EngineIgnitor/MM_Configs/MM_ModularLaunchPads.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_ModularLaunchPads.cfg
@@ -1,6 +1,6 @@
 //Written by Zorg
 // //A large ignite range is given to allow for the large exhaust holes in some of the MLP pads. Technically they have the launch clamp module but some are quite large full size pads. Using a large ignite range should have minimal gameplay impact.
-@PART[AM_MLP*]:HAS[@MODULE[LaunchClamp]]:AFTER[EngineIgnitor]
+@PART[AM_MLP*]:HAS[@MODULE[LaunchClamp]]:NEEDS[ModularLaunchPads]:AFTER[EngineIgnitor]
 {
   MODULE
   {

--- a/GameData/EngineIgnitor/MM_Configs/MM_ModularLaunchPads.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_ModularLaunchPads.cfg
@@ -1,12 +1,12 @@
 //Written by Zorg
 // //A large ignite range is given to allow for the large exhaust holes in some of the MLP pads. Technically they have the launch clamp module but some are quite large full size pads. Using a large ignite range should have minimal gameplay impact.
-@PART[*]:HAS[@MODULE[LaunchClamp],!launchClamp1]:AFTER[EngineIgnitor]
+@PART[AM_MLP*]:HAS[@MODULE[LaunchClamp]]:AFTER[EngineIgnitor]
 {
   MODULE
   {
       name = ModuleExternalIgnitor
       IgnitorType = External
-      IgniteRange = 20.0
+      IgniteRange = 30.0
       provideRequiredResources = true
   }
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_ModularLaunchPads.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_ModularLaunchPads.cfg
@@ -1,0 +1,12 @@
+//Written by Zorg
+// //A large ignite range is given to allow for the large exhaust holes in some of the MLP pads. Technically they have the launch clamp module but some are quite large full size pads. Using a large ignite range should have minimal gameplay impact.
+@PART[*]:HAS[@MODULE[LaunchClamp],!launchClamp1]:AFTER[EngineIgnitor]
+{
+  MODULE
+  {
+      name = ModuleExternalIgnitor
+      IgnitorType = External
+      IgniteRange = 10.0
+      provideRequiredResources = true
+  }
+}

--- a/GameData/EngineIgnitor/MM_Configs/MM_ModularLaunchPads.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_ModularLaunchPads.cfg
@@ -6,7 +6,7 @@
   {
       name = ModuleExternalIgnitor
       IgnitorType = External
-      IgniteRange = 10.0
+      IgniteRange = 20.0
       provideRequiredResources = true
   }
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
@@ -1,7 +1,7 @@
 //By Zorg
 //Ignitions based on real world limits, using RO configs as main reference
 
-@PART[engine-lfo-advanced-125-1]//Space X Raptor Sea level
+@PART[engine-lfo-advanced-125-1]:NEEDS[NearFutureLaunchVehicles]//Space X Raptor Sea level
 {
 	MODULE
 	{
@@ -14,7 +14,7 @@
 	}
 }
 
-@PART[engine-lfo-advanced-125-2]//RS-18, LMAE modified to run methalox. No ignition data found. Using LMAE values from RO
+@PART[engine-lfo-advanced-125-2]:NEEDS[NearFutureLaunchVehicles]//RS-18, LMAE modified to run methalox. No ignition data found. Using LMAE values from RO
 {
 	MODULE
 	{
@@ -27,7 +27,7 @@
 	}
 }
 
-@PART[engine-lfo-advanced-25-1]//Blue Origin BE-4
+@PART[engine-lfo-advanced-25-1]:NEEDS[NearFutureLaunchVehicles]//Blue Origin BE-4
 {
 	MODULE
 	{
@@ -40,7 +40,7 @@
 	}
 }
 
-@PART[engine-lfo-advanced-25-2]//Space X Raptor Vacuum
+@PART[engine-lfo-advanced-25-2]:NEEDS[NearFutureLaunchVehicles]//Space X Raptor Vacuum
 {
 	MODULE
 	{

--- a/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
@@ -1,30 +1,28 @@
 //By Zorg
-//Ignitions based on real world limits, using RO configs as main reference
 
-@PART[engine-lfo-advanced-125-1]:NEEDS[NearFutureLaunchVehicles]//Space X Raptor Sea level
+@PART[engine-lfo-advanced-125-1]:NEEDS[NearFutureLaunchVehicles]//Space X Raptor Sea level. RO has 5 ignitions but given the use of sl raptors on starship Im going with unlimited spark igntions here. NFLV is also high tech level.
 {
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 5
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 20
+    ECforIgnition = 35
 		IgnitorType = Internal
 	}
 }
 
-@PART[engine-lfo-advanced-125-2]:NEEDS[NearFutureLaunchVehicles]//RS-18, LMAE modified to run methalox. No ignition data found. Using LMAE values from RO
+//RS-18 is an LMAE modified to run methalox. No ignition data found. Assuming a spark ignitor for unlimited ignitions which is reasonable if it got adoopted into the constellation program. Balanced with higher EC requirement given its size. Its also in a high tech node since its NFLV.
+@PART[engine-lfo-advanced-125-2]:NEEDS[NearFutureLaunchVehicles]
 {
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 10
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 20
+    ECforIgnition = 30
 		IgnitorType = Internal
 	}
 }
@@ -43,7 +41,7 @@
 	}
 }
 
-@PART[engine-lfo-advanced-25-2]:NEEDS[NearFutureLaunchVehicles]//Space X Raptor Vacuum
+@PART[engine-lfo-advanced-25-2]:NEEDS[NearFutureLaunchVehicles]//Space X Raptor Vacuum. Unlimited ignitions as per RO. Balanced with higher EC requirment for igniting.
 {
 	MODULE
 	{
@@ -52,6 +50,6 @@
 		IgnitorType = Internal Unlimited
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 20
+    ECforIgnition = 50
 	}
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
@@ -1,0 +1,47 @@
+@PART[engine-lfo-advanced-125-1]//Space X Raptor Sea level
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 5
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[engine-lfo-advanced-125-2]//RS-18, LMAE modified to run methalox. No ignition data found. Using LMAE values from RO
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 10
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[engine-lfo-advanced-25-1]//Blue Origin BE-4
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 4
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
+@PART[engine-lfo-advanced-25-2]//Space X Raptor Vacuum
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 100
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}

--- a/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
@@ -10,6 +10,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+    ECforIgnition = 20
 	}
 }
 
@@ -22,6 +23,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+    ECforIgnition = 20
 	}
 }
 
@@ -34,6 +36,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+    ECforIgnition = 50
 	}
 }
 
@@ -42,9 +45,9 @@
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 100
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
+    ECforIgnition = 20
 	}
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
@@ -1,3 +1,6 @@
+//By Zorg
+//Ignitions based on real world limits, using RO configs as main reference
+
 @PART[engine-lfo-advanced-125-1]//Space X Raptor Sea level
 {
 	MODULE

--- a/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
@@ -11,6 +11,7 @@
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
     ECforIgnition = 20
+		IgnitorType = Internal
 	}
 }
 
@@ -24,6 +25,7 @@
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
     ECforIgnition = 20
+		IgnitorType = Internal
 	}
 }
 
@@ -37,6 +39,7 @@
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
     ECforIgnition = 50
+		IgnitorType = Internal
 	}
 }
 
@@ -46,6 +49,7 @@
 	{
 		name = ModuleEngineIgnitor
 		AutoIgnitionTemperature = 800
+		IgnitorType = Internal Unlimited
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
     ECforIgnition = 20

--- a/GameData/EngineIgnitor/MM_Configs/MM_NearFutureSpaceCraft.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_NearFutureSpaceCraft.cfg
@@ -1,0 +1,82 @@
+//Near Future Spacecraft. Most of these engines dont have exact IRL analogues. Ignitions based on real equivalents where available, RO configs as main reference, best guess based on role for the rest.
+//By Zorg
+@PART[engine-rocket-pack-1]//Super draco
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+    ECforIgnition = 20
+		IgnitorType = Internal unlimited
+	}
+}
+
+@PART[engine-rocket-pack-2]//Super draco
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+    ECforIgnition = 20
+		IgnitorType = Internal unlimited
+	}
+}
+
+@PART[orbital-engine-25]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 25
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+    ECforIgnition = 20
+		IgnitorType = Internal
+	}
+}
+
+@PART[orbital-engine-125]//Seems like an advanced AJ10
+{
+  MODULE
+	{
+		name = ModuleEngineIgnitor
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+    ECforIgnition = 20
+		IgnitorType = Internal unlimited
+	}
+}
+
+@PART[orbital-engine-375]//Seems like an advanced AJ10
+{
+  MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 25
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+    ECforIgnition = 20
+		IgnitorType = Internal
+	}
+}
+
+@PART[orbital-engine-0625]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 25
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+    ECforIgnition = 20
+    IgnitorType = Internal
+	}
+}

--- a/GameData/EngineIgnitor/MM_Configs/MM_NearFutureSpaceCraft.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_NearFutureSpaceCraft.cfg
@@ -53,7 +53,7 @@
 	}
 }
 
-@PART[orbital-engine-375]:NEEDS[NearFutureSpacecraft]]//Seems like an advanced AJ10, unlimited ignitions in RO
+@PART[orbital-engine-375]:NEEDS[NearFutureSpacecraft]//Seems like an advanced AJ10, unlimited ignitions in RO
 {
   MODULE
 	{

--- a/GameData/EngineIgnitor/MM_Configs/MM_NearFutureSpaceCraft.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_NearFutureSpaceCraft.cfg
@@ -1,5 +1,7 @@
 //Near Future Spacecraft. Most of these engines dont have exact IRL analogues. Ignitions based on real equivalents where available, RO configs as main reference, best guess based on role for the rest.
 //By Zorg
+
+//Unlimited ignitions for super draco. Higher EC cost to compensate
 @PART[engine-rocket-pack-1]:NEEDS[NearFutureSpacecraft]//Super draco
 {
 	MODULE
@@ -12,7 +14,7 @@
 		IgnitorType = Internal unlimited
 	}
 }
-
+//Unlimited ignitions for super draco. Higher EC cost to compensate
 @PART[engine-rocket-pack-2]:NEEDS[NearFutureSpacecraft]//Super draco
 {
 	MODULE
@@ -48,7 +50,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 20
+    ECforIgnition = 25
 		IgnitorType = Internal unlimited
 	}
 }
@@ -62,7 +64,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 20
+    ECforIgnition = 25
 		IgnitorType = Internal
 	}
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_NearFutureSpaceCraft.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_NearFutureSpaceCraft.cfg
@@ -1,6 +1,6 @@
 //Near Future Spacecraft. Most of these engines dont have exact IRL analogues. Ignitions based on real equivalents where available, RO configs as main reference, best guess based on role for the rest.
 //By Zorg
-@PART[engine-rocket-pack-1]//Super draco
+@PART[engine-rocket-pack-1]:NEEDS[NearFutureSpacecraft]//Super draco
 {
 	MODULE
 	{
@@ -13,7 +13,7 @@
 	}
 }
 
-@PART[engine-rocket-pack-2]//Super draco
+@PART[engine-rocket-pack-2]:NEEDS[NearFutureSpacecraft]//Super draco
 {
 	MODULE
 	{
@@ -26,7 +26,7 @@
 	}
 }
 
-@PART[orbital-engine-25]//
+@PART[orbital-engine-25]:NEEDS[NearFutureSpacecraft]//
 {
 	MODULE
 	{
@@ -40,7 +40,7 @@
 	}
 }
 
-@PART[orbital-engine-125]//Seems like an advanced AJ10
+@PART[orbital-engine-125]:NEEDS[NearFutureSpacecraft]//Seems like an advanced AJ10, unlimited ignitions in RO
 {
   MODULE
 	{
@@ -53,7 +53,7 @@
 	}
 }
 
-@PART[orbital-engine-375]//Seems like an advanced AJ10
+@PART[orbital-engine-375]:NEEDS[NearFutureSpacecraft]]//Seems like an advanced AJ10, unlimited ignitions in RO
 {
   MODULE
 	{
@@ -67,7 +67,7 @@
 	}
 }
 
-@PART[orbital-engine-0625]//
+@PART[orbital-engine-0625]:NEEDS[NearFutureSpacecraft]//
 {
 	MODULE
 	{

--- a/GameData/EngineIgnitor/MM_Configs/MM_PartOverhauls.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_PartOverhauls.cfg
@@ -1,0 +1,137 @@
+//-----------------PART OVERHAULS--------------------
+//LV-T15
+@PART[liquidEngineT15]:NEEDS[PartOverhauls]
+{
+	@TechRequired = generalRocketry
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 2
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.7  //0-1
+        ECforIgnition = 20
+    }
+}
+@PART[liquidEngineT15_Boattail]:NEEDS[PartOverhauls]
+{
+	@TechRequired = generalRocketry
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 2
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.7  //0-1
+        ECforIgnition = 20
+    }
+}
+// LV-T30 Engine
+@PART[liquidEngineT30]:NEEDS[PartOverhauls]
+{
+	@TechRequired = basicRocketry
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 0
+        AutoIgnitionTemperature = 800
+        IgnitorType = External
+    }
+}
+@PART[liquidEngineT30_Boattail]:NEEDS[PartOverhauls]
+{
+	@TechRequired = basicRocketry
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 0
+        AutoIgnitionTemperature = 800
+        IgnitorType = External
+    }
+}
+
+
+// LV-T45 Engine
+@PART[liquidEngineT45]:NEEDS[PartOverhauls]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 4
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+        ECforIgnition = 20
+    }
+}
+@PART[liquidEngineT45_Boat]:NEEDS[PartOverhauls]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 4
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+        ECforIgnition = 20
+    }
+}
+
+// LV-909 Engine
+@PART[liquidEngine909]:NEEDS[PartOverhauls]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 8
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+        ECforIgnition = 10
+    }
+}
+@PART[liquidEngine909_Boattail]:NEEDS[PartOverhauls]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 8
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+        ECforIgnition = 10
+    }
+}
+// LV-303 Engine
+@PART[liquidEngine303]:NEEDS[PartOverhauls]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 24
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+        ECforIgnition = 10
+    }
+}
+@PART[liquidEngine303_Boattail]:NEEDS[PartOverhauls]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 24
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+        ECforIgnition = 10
+    }
+}

--- a/GameData/EngineIgnitor/MM_Configs/MM_QuizTech_TechUpgrades.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_QuizTech_TechUpgrades.cfg
@@ -1,5 +1,5 @@
 // Ignitor upgrade 8 - tier 8
-@PART[Mk2_LinAerospike]:FINAL
+@PART[Mk2_LinAerospike]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -14,7 +14,7 @@
         }
     }
 }
-@PART[Mk2_NERVA]:FINAL
+@PART[Mk2_NERVA]
 {
     @MODULE[ModuleEngineIgnitor]
     {        

--- a/GameData/EngineIgnitor/MM_Configs/MM_RLA_TechUpgrades.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_RLA_TechUpgrades.cfg
@@ -1,20 +1,20 @@
 // ======================= Engines Ignition Upgrades =======================
 // Ignitor upgrade 1 - tier 4
-@PART[RLA_small_highthrust]:FINAL
+@PART[RLA_small_highthrust]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_1
                 techRequired__ = miniaturization
-                description__ = 
+                description__ =
 				IgnitorType = Internal
 				UseUllageSimulation = true
 				ChanceWhenUnstable = 0.2  //0-1
-                IgnitionsAvailable = 4                
+                IgnitionsAvailable = 4
             }
         }
     }
@@ -22,34 +22,34 @@
 
 
 // Ignitor upgrade 2 - tier 5
-@PART[RLA_small_spike]:FINAL
+@PART[RLA_small_spike]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_2
                 techRequired__ = precisionEngineering
-                description__ = 
-                IgnitionsAvailable = 32                
+                description__ =
+                IgnitionsAvailable = 32
             }
         }
     }
 }
-@PART[RLA_tiny_vac]:FINAL
+@PART[RLA_tiny_vac]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_2
                 techRequired__ = precisionEngineering
-                description__ = 
-                IgnitionsAvailable = 32                
+                description__ =
+                IgnitionsAvailable = 32
             }
         }
     }
@@ -57,10 +57,10 @@
 
 
 // Ignitor upgrade 8 - tier 8
-@PART[RLA_small_ntr]:FINAL
+@PART[RLA_small_ntr]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE

--- a/GameData/EngineIgnitor/MM_Configs/MM_ReStockPlus.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_ReStockPlus.cfg
@@ -1,0 +1,73 @@
+//ReStockPlus
+//By Zorg
+
+@PART[restock-engine-boar]:NEEDS[ReStockPlus]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 0
+        AutoIgnitionTemperature = 800
+        IgnitorType = External (launch Clamp)
+	      UseUllageSimulation = false
+    		ChanceWhenUnstable = 0.2  //0-1
+        ECforIgnition = 35
+    }
+}
+
+@PART[restock-engine-cherenkov]:NEEDS[ReStockPlus]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 18
+        AutoIgnitionTemperature = 500
+        IgnitorType = Internal
+	    UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 10
+    DontUseIgnitorIfMultiModeOn = true
+    }
+}
+
+@PART[restock-engine-125-valiant]:NEEDS[ReStockPlus]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 0
+        AutoIgnitionTemperature = 800
+        IgnitorType = External (launch Clamp)
+	      UseUllageSimulation = false
+    		ChanceWhenUnstable = 0.2  //0-1
+        ECforIgnition = 20
+    }
+}
+
+@PART[restock-engine-torch]:NEEDS[ReStockPlus]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 0
+        AutoIgnitionTemperature = 800
+        IgnitorType = External (launch Clamp)
+	      UseUllageSimulation = false
+    		ChanceWhenUnstable = 0.2  //0-1
+        ECforIgnition = 10
+    }
+}
+
+@PART[restock-engine-375-corgi]:NEEDS[ReStockPlus]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 10
+        AutoIgnitionTemperature = 500
+        IgnitorType = Internal
+	    UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 15
+    }
+}

--- a/GameData/EngineIgnitor/MM_Configs/MM_Stock.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Stock.cfg
@@ -5,7 +5,7 @@
     {
         name = ModuleExternalIgnitor
         IgnitorType = External
-        IgniteRange = 10.0
+        IgniteRange = 20.0
         provideRequiredResources = true
     }
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_Stock.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Stock.cfg
@@ -52,6 +52,66 @@
     }
 }
 
+// Rockomax 48-7S - New Version
+@PART[liquidEngineMini_v2]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 20
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.4  //0-1
+        ECforIgnition = 10
+    }
+}
+
+// LV-909 Engine - New Version
+@PART[liquidEngine3_v2]:NEEDS[!PartOverhauls]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 8
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+        ECforIgnition = 10
+    }
+}
+
+// Rockomax "Poodle" Engine
+@PART[liquidEngine2-2_v2]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 24
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+        ECforIgnition = 20
+    }
+}
+
+//Ant
+@PART[microEngine_v2]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 20
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+        ECforIgnition = 2
+    }
+}
+
 // LV-N Atomic Engine
 @PART[nuclearEngine]
 {
@@ -166,6 +226,19 @@
         ECforIgnition = 10
     }
 }
+@PART[smallRadialEngine_v2]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 18
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.4  //0-1
+        ECforIgnition = 10
+    }
+}
 
 // LV-1 Engine
 @PART[microEngine]
@@ -197,7 +270,19 @@
         ECforIgnition = 2
     }
 }
-
+@PART[radialEngineMini_v2]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 30
+        AutoIgnitionTemperature = 500
+        IgnitorType = Internal
+		UseUllageSimulation = false
+		ChanceWhenUnstable = 0.7  //0-1
+        ECforIgnition = 2
+    }
+}
 
 
 @PART[Size2LFB]
@@ -249,143 +334,7 @@
         IgnitorType = External (Launch Clamps)
     }
 }
-//-----------------PART OVERHAULS--------------------
-//LV-T15
-@PART[liquidEngineT15]:NEEDS[PartOverhauls]
-{
-	@TechRequired = generalRocketry
-    MODULE
-    {
-        name = ModuleEngineIgnitor
-        IgnitionsAvailable = 2
-        AutoIgnitionTemperature = 800
-        IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.7  //0-1
-        ECforIgnition = 20
-    }
-}
-@PART[liquidEngineT15_Boattail]:NEEDS[PartOverhauls]
-{
-	@TechRequired = generalRocketry
-    MODULE
-    {
-        name = ModuleEngineIgnitor
-        IgnitionsAvailable = 2
-        AutoIgnitionTemperature = 800
-        IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.7  //0-1
-        ECforIgnition = 20
-    }
-}
-// LV-T30 Engine
-@PART[liquidEngineT30]:NEEDS[PartOverhauls]
-{
-	@TechRequired = basicRocketry
-    MODULE
-    {
-        name = ModuleEngineIgnitor
-        IgnitionsAvailable = 0
-        AutoIgnitionTemperature = 800
-        IgnitorType = External
-    }
-}
-@PART[liquidEngineT30_Boattail]:NEEDS[PartOverhauls]
-{
-	@TechRequired = basicRocketry
-    MODULE
-    {
-        name = ModuleEngineIgnitor
-        IgnitionsAvailable = 0
-        AutoIgnitionTemperature = 800
-        IgnitorType = External
-    }
-}
 
-
-// LV-T45 Engine
-@PART[liquidEngineT45]:NEEDS[PartOverhauls]
-{
-    MODULE
-    {
-        name = ModuleEngineIgnitor
-        IgnitionsAvailable = 4
-        AutoIgnitionTemperature = 800
-        IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.2  //0-1
-        ECforIgnition = 20
-    }
-}
-@PART[liquidEngineT45_Boat]:NEEDS[PartOverhauls]
-{
-    MODULE
-    {
-        name = ModuleEngineIgnitor
-        IgnitionsAvailable = 4
-        AutoIgnitionTemperature = 800
-        IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.2  //0-1
-        ECforIgnition = 20
-    }
-}
-
-// LV-909 Engine
-@PART[liquidEngine909]:NEEDS[PartOverhauls]
-{
-    MODULE
-    {
-        name = ModuleEngineIgnitor
-        IgnitionsAvailable = 8
-        AutoIgnitionTemperature = 800
-        IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.2  //0-1
-        ECforIgnition = 10
-    }
-}
-@PART[liquidEngine909_Boattail]:NEEDS[PartOverhauls]
-{
-    MODULE
-    {
-        name = ModuleEngineIgnitor
-        IgnitionsAvailable = 8
-        AutoIgnitionTemperature = 800
-        IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.2  //0-1
-        ECforIgnition = 10
-    }
-}
-// LV-303 Engine
-@PART[liquidEngine303]:NEEDS[PartOverhauls]
-{
-    MODULE
-    {
-        name = ModuleEngineIgnitor
-        IgnitionsAvailable = 24
-        AutoIgnitionTemperature = 800
-        IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.2  //0-1
-        ECforIgnition = 10
-    }
-}
-@PART[liquidEngine303_Boattail]:NEEDS[PartOverhauls]
-{
-    MODULE
-    {
-        name = ModuleEngineIgnitor
-        IgnitionsAvailable = 24
-        AutoIgnitionTemperature = 800
-        IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.2  //0-1
-        ECforIgnition = 10
-    }
-}
 
 //@PART[*]:HAS[@MODULE[ModuleEngine*],!MODULE[ModuleEngine*]:HAS[@PROPELLANT[MonoPropellant]],!MODULE[ModuleEngine*]:HAS[@PROPELLANT[XenonGas]],!MODULE[ModuleRCS],!MODULE[ModuleEngine*]:HAS[@PROPELLANT[IntakeAir]],!MODULE[ModuleEngine*]:HAS[@PROPELLANT[IntakeAtm]],!RESOURCE[AblativeOil],!RESOURCE[SolidFuel],!RESOURCE[Karbonite],!RESOURCE[FSCoolant],!RESOURCE[IntakeLqd],!MODULE[ModuleEngineIgnitor]]
 //{
@@ -400,48 +349,3 @@
 //		ECforIgnition = 20
 //	}
 //}
-
-// Rockomax 48-7S - New Version
-@PART[liquidEngineMini_v2]
-{
-    MODULE
-    {
-        name = ModuleEngineIgnitor
-        IgnitionsAvailable = 20
-        AutoIgnitionTemperature = 800
-        IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.4  //0-1
-        ECforIgnition = 10
-    }
-}
-
-// LV-909 Engine - New Version
-@PART[liquidEngine3_v2]:NEEDS[!PartOverhauls]
-{
-    MODULE
-    {
-        name = ModuleEngineIgnitor
-        IgnitionsAvailable = 8
-        AutoIgnitionTemperature = 800
-        IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.2  //0-1
-        ECforIgnition = 10
-    }
-}
-
-// Rockomax "Poodle" Engine
-@PART[liquidEngine2-2_v2]
-{
-    MODULE
-    {
-        name = ModuleEngineIgnitor
-        IgnitionsAvailable = 24
-        AutoIgnitionTemperature = 800
-        IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.2  //0-1
-        ECforIgnition = 20
-    }
-}

--- a/GameData/EngineIgnitor/MM_Configs/MM_Stock.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Stock.cfg
@@ -5,7 +5,7 @@
     {
         name = ModuleExternalIgnitor
         IgnitorType = External
-        IgniteRange = 3.0
+        IgniteRange = 10.0
         provideRequiredResources = true
     }
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_Stock.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Stock.cfg
@@ -1,5 +1,5 @@
 // TT18-A Launch Stability Enhancer
-@PART[launchClamp1]:FINAL
+@PART[launchClamp1]
 {
     MODULE
     {
@@ -11,7 +11,7 @@
 }
 
 // Rockomax "Mailsail" Engine
-@PART[liquidEngine1-2]:FINAL
+@PART[liquidEngine1-2]
 {
     MODULE
     {
@@ -23,7 +23,7 @@
 }
 
 // Rockomax "Skipper" Engine
-@PART[engineLargeSkipper]:FINAL
+@PART[engineLargeSkipper]
 {
     MODULE
     {
@@ -38,7 +38,7 @@
 }
 
 // Rockomax "Poodle" Engine
-@PART[liquidEngine2-2]:FINAL
+@PART[liquidEngine2-2]
 {
     MODULE
     {
@@ -53,7 +53,7 @@
 }
 
 // LV-N Atomic Engine
-@PART[nuclearEngine]:FINAL
+@PART[nuclearEngine]
 {
     MODULE
     {
@@ -68,7 +68,7 @@
 }
 
 // Toroidal Aerospike Engine
-@PART[toroidalAerospike]:FINAL
+@PART[toroidalAerospike]
 {
     MODULE
     {
@@ -80,7 +80,7 @@
 }
 
 // LV-T30 Engine
-@PART[liquidEngine]:NEEDS[!PartOverhauls]:FINAL
+@PART[liquidEngine]:NEEDS[!PartOverhauls]
 {
     MODULE
     {
@@ -91,7 +91,7 @@
     }
 }
 // LV-T45 Engine
-@PART[liquidEngine2]:NEEDS[!PartOverhauls]:FINAL
+@PART[liquidEngine2]:NEEDS[!PartOverhauls]
 {
     MODULE
     {
@@ -106,7 +106,7 @@
 }
 
 // LV-909 Engine
-@PART[liquidEngine3]:NEEDS[!PartOverhauls]:FINAL
+@PART[liquidEngine3]:NEEDS[!PartOverhauls]
 {
     MODULE
     {
@@ -122,7 +122,7 @@
 
 
 // Rockomax Mark 55 Radial Engine
-@PART[radialLiquidEngine1-2]:FINAL
+@PART[radialLiquidEngine1-2]
 {
     MODULE
     {
@@ -138,7 +138,7 @@
 
 
 // Rockomax 48-7S
-@PART[liquidEngineMini]:FINAL
+@PART[liquidEngineMini]
 {
     MODULE
     {
@@ -153,7 +153,7 @@
 }
 
 // Rockomax 24-77 Engine
-@PART[smallRadialEngine]:FINAL
+@PART[smallRadialEngine]
 {
     MODULE
     {
@@ -168,7 +168,7 @@
 }
 
 // LV-1 Engine
-@PART[microEngine]:FINAL
+@PART[microEngine]
 {
 
     MODULE
@@ -184,7 +184,7 @@
 }
 
 // LV-1R Engine
-@PART[radialEngineMini]:FINAL
+@PART[radialEngineMini]
 {
     MODULE
     {
@@ -200,7 +200,7 @@
 
 
 
-@PART[Size2LFB]:FINAL
+@PART[Size2LFB]
 {
     MODULE
     {
@@ -212,7 +212,7 @@
 }
 
 // S3 KS-25x4 "Mammoth"
-@PART[Size3EngineCluster]:FINAL
+@PART[Size3EngineCluster]
 {
     MODULE
     {
@@ -224,7 +224,7 @@
 }
 
 // Kerbodyne KR-2L+ "Rhino"
-@PART[Size3AdvancedEngine]:FINAL
+@PART[Size3AdvancedEngine]
 {
     MODULE
     {
@@ -239,7 +239,7 @@
 }
 
 //S3 KS-25 "Vector"
-@PART[SSME]:FINAL
+@PART[SSME]
 {
     MODULE
     {
@@ -387,7 +387,7 @@
     }
 }
 
-//@PART[*]:HAS[@MODULE[ModuleEngine*],!MODULE[ModuleEngine*]:HAS[@PROPELLANT[MonoPropellant]],!MODULE[ModuleEngine*]:HAS[@PROPELLANT[XenonGas]],!MODULE[ModuleRCS],!MODULE[ModuleEngine*]:HAS[@PROPELLANT[IntakeAir]],!MODULE[ModuleEngine*]:HAS[@PROPELLANT[IntakeAtm]],!RESOURCE[AblativeOil],!RESOURCE[SolidFuel],!RESOURCE[Karbonite],!RESOURCE[FSCoolant],!RESOURCE[IntakeLqd],!MODULE[ModuleEngineIgnitor]]:FINAL
+//@PART[*]:HAS[@MODULE[ModuleEngine*],!MODULE[ModuleEngine*]:HAS[@PROPELLANT[MonoPropellant]],!MODULE[ModuleEngine*]:HAS[@PROPELLANT[XenonGas]],!MODULE[ModuleRCS],!MODULE[ModuleEngine*]:HAS[@PROPELLANT[IntakeAir]],!MODULE[ModuleEngine*]:HAS[@PROPELLANT[IntakeAtm]],!RESOURCE[AblativeOil],!RESOURCE[SolidFuel],!RESOURCE[Karbonite],!RESOURCE[FSCoolant],!RESOURCE[IntakeLqd],!MODULE[ModuleEngineIgnitor]]
 //{
 //	MODULE
 //	{
@@ -402,7 +402,7 @@
 //}
 
 // Rockomax 48-7S - New Version
-@PART[liquidEngineMini_v2]:FINAL
+@PART[liquidEngineMini_v2]
 {
     MODULE
     {
@@ -417,7 +417,7 @@
 }
 
 // LV-909 Engine - New Version
-@PART[liquidEngine3_v2]:NEEDS[!PartOverhauls]:FINAL
+@PART[liquidEngine3_v2]:NEEDS[!PartOverhauls]
 {
     MODULE
     {
@@ -432,7 +432,7 @@
 }
 
 // Rockomax "Poodle" Engine
-@PART[liquidEngine2-2_v2]:FINAL
+@PART[liquidEngine2-2_v2]
 {
     MODULE
     {
@@ -445,5 +445,3 @@
         ECforIgnition = 20
     }
 }
-
-

--- a/GameData/EngineIgnitor/MM_Configs/MM_Stock_MakingHistory.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Stock_MakingHistory.cfg
@@ -1,0 +1,101 @@
+//Making history configs
+// Based on IRL equivalents, using RO as reference
+//by Zorg
+
+@PART[liquidEngineKE-1]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 0
+        AutoIgnitionTemperature = 800
+        IgnitorType = External (launch Clamp)
+	      UseUllageSimulation = false
+    		ChanceWhenUnstable = 0.4  //0-1
+        ECforIgnition = 50
+    }
+}
+
+@PART[LiquidEngineLV-T91]//Based on LR91
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 1
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+    		UseUllageSimulation = false
+    		ChanceWhenUnstable = 0.4  //0-1
+        ECforIgnition = 15
+    }
+}
+
+@PART[LiquidEngineLV-TX87]//Based on LR87
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 1 //To allow for Titan III style air start
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+    		UseUllageSimulation = false
+    		ChanceWhenUnstable = 0.4  //0-1
+        ECforIgnition = 15
+    }
+}
+
+@PART[LiquidEngineRE-I2]//Based on J2
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 3
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+    		UseUllageSimulation = false
+    		ChanceWhenUnstable = 0.4  //0-1
+        ECforIgnition = 20
+    }
+}
+
+@PART[LiquidEngineRE-J10]//Based on Apollo SPS AJ10
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 50
+        AutoIgnitionTemperature = 800
+        IgnitorType = Internal
+    		UseUllageSimulation = false
+    		ChanceWhenUnstable = 0.4  //0-1
+        ECforIgnition = 15
+    }
+}
+
+@PART[liquidEngineRK-7]//Based on Soyuz RD107
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 0
+        AutoIgnitionTemperature = 800
+        IgnitorType = External (launch Clamp)
+	      UseUllageSimulation = false
+    		ChanceWhenUnstable = 0.4  //0-1
+        ECforIgnition = 30
+    }
+}
+
+@PART[liquidEngineRV-1]//Probably soyuz verniers? Who can tell? Giving it similar ignitions to stock radial.
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        IgnitionsAvailable = 18
+        AutoIgnitionTemperature = 800
+        IgnitorType = External (launch Clamp)
+	      UseUllageSimulation = false
+    		ChanceWhenUnstable = 0.4  //0-1
+        ECforIgnition = 10
+    }
+}

--- a/GameData/EngineIgnitor/MM_Configs/MM_Stock_TechUpgrades.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Stock_TechUpgrades.cfg
@@ -2,247 +2,247 @@
 
 // ======================= Engines Ignition Upgrades =======================
 // Ignitor upgrade 1
-@PART[liquidEngine]:FINAL
+@PART[liquidEngine]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_1
                 techRequired__ = miniaturization
-                description__ = 
+                description__ =
 				IgnitorType = Internal
 				UseUllageSimulation = true
 				ChanceWhenUnstable = 0.2  //0-1
-                IgnitionsAvailable = 4                
+                IgnitionsAvailable = 4
             }
         }
     }
 }
-@PART[liquidEngine2]:FINAL
+@PART[liquidEngine2]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_1
                 techRequired__ = miniaturization
-                description__ = 
-                IgnitionsAvailable = 8                
+                description__ =
+                IgnitionsAvailable = 8
             }
         }
     }
 }
-@PART[liquidEngine3]:FINAL
+@PART[liquidEngine3]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_1
                 techRequired__ = miniaturization
-                description__ = 
-                IgnitionsAvailable = 16                
+                description__ =
+                IgnitionsAvailable = 16
             }
         }
     }
 }
 
 // Ignitor upgrade 2
-@PART[radialLiquidEngine1-2]:FINAL
+@PART[radialLiquidEngine1-2]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_2
                 techRequired__ = precisionEngineering
-                description__ = 
-                IgnitionsAvailable = 28                
+                description__ =
+                IgnitionsAvailable = 28
             }
         }
     }
 }
 
-@PART[liquidEngine3]:FINAL
+@PART[liquidEngine3]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_2
                 techRequired__ = largeElectrics
-                description__ = 
-                IgnitionsAvailable = 20                
+                description__ =
+                IgnitionsAvailable = 20
             }
         }
     }
 }
-@PART[microEngine]:FINAL
+@PART[microEngine]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_2
                 techRequired__ = precisionEngineering
-                description__ = 
-                IgnitionsAvailable = 26                    
+                description__ =
+                IgnitionsAvailable = 26
             }
         }
     }
 }
-@PART[liquidEngineMini]:FINAL
+@PART[liquidEngineMini]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_2
                 techRequired__ = precisionEngineering
-                description__ = 
-                IgnitionsAvailable = 24                    
+                description__ =
+                IgnitionsAvailable = 24
             }
         }
     }
 }
 
 // Ignitor upgrade 3
-@PART[liquidEngine2-2]:FINAL
+@PART[liquidEngine2-2]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_3
                 techRequired__ = largeElectrics
-                description__ = 
-                IgnitionsAvailable = 30                
+                description__ =
+                IgnitionsAvailable = 30
             }
         }
     }
 }
 
-@PART[microEngine]:FINAL
+@PART[microEngine]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_3
                 techRequired__ = largeElectrics
-                description__ = 
-                IgnitionsAvailable = 30                    
+                description__ =
+                IgnitionsAvailable = 30
             }
         }
     }
 }
 
 
-@PART[smallRadialEngine]:FINAL
+@PART[smallRadialEngine]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_3
                 techRequired__ = largeElectrics
-                description__ = 
-                IgnitionsAvailable = 36                    
+                description__ =
+                IgnitionsAvailable = 36
             }
         }
     }
 }
 // Ignitor upgrade 4
-@PART[microEngine]:FINAL
+@PART[microEngine]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_4
                 techRequired__ = highPerformanceFuelSystems
-                description__ = 
-                IgnitionsAvailable = 36                
+                description__ =
+                IgnitionsAvailable = 36
             }
         }
     }
 }
-@PART[radialEngineMini]:FINAL
+@PART[radialEngineMini]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_4
                 techRequired__ = highPerformanceFuelSystems
-                description__ = 
-                IgnitionsAvailable = 36                 
+                description__ =
+                IgnitionsAvailable = 36
             }
         }
     }
 }
-@PART[liquidEngineMini]:FINAL
+@PART[liquidEngineMini]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_4
                 techRequired__ = highPerformanceFuelSystems
-                description__ = 
-                IgnitionsAvailable = 32              
+                description__ =
+                IgnitionsAvailable = 32
             }
         }
     }
 }
-@PART[smallRadialEngine]:FINAL
+@PART[smallRadialEngine]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_4
                 techRequired__ = highPerformanceFuelSystems
-                description__ = 
-                IgnitionsAvailable = 24             
+                description__ =
+                IgnitionsAvailable = 24
             }
         }
     }
 }
 // Ignitor upgrade 8
-@PART[SSME]:FINAL
+@PART[SSME]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
@@ -253,83 +253,83 @@
                 IgnitionsAvailable = 4
                 IgnitorType = Internal
                 UseUllageSimulation = true
-                ChanceWhenUnstable = 0.2 
+                ChanceWhenUnstable = 0.2
                 ECforIgnition = 40
             }
         }
     }
 }
-@PART[nuclearEngine]:FINAL
+@PART[nuclearEngine]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_8
                 techRequired__ = experimentalElectrics
-                description__ = 
+                description__ =
                 IgnitionsAvailable = 45
             }
         }
     }
 }
 //-----------------------PART OVERHAULS--------------------
-@PART[liquidEngineT30|liquidEngineT30_Boattail]:NEEDS[PartOverhauls]:FINAL
+@PART[liquidEngineT30|liquidEngineT30_Boattail]:NEEDS[PartOverhauls]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_4
                 techRequired__ = miniaturization
-                description__ = 
+                description__ =
 				IgnitorType = Internal
 				UseUllageSimulation = true
 				ChanceWhenUnstable = 0.2  //0-1
-                IgnitionsAvailable = 4                
+                IgnitionsAvailable = 4
             }
         }
     }
 }
-@PART[liquidEngineT45|liquidEngineT45_Boat]:NEEDS[PartOverhauls]:FINAL
+@PART[liquidEngineT45|liquidEngineT45_Boat]:NEEDS[PartOverhauls]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_4
                 techRequired__ = miniaturization
-                description__ = 
-                IgnitionsAvailable = 8                
+                description__ =
+                IgnitionsAvailable = 8
             }
         }
     }
 }
 
-@PART[liquidEngine909|liquidEngine909_Boattail]:NEEDS[PartOverhauls]:FINAL
+@PART[liquidEngine909|liquidEngine909_Boattail]:NEEDS[PartOverhauls]
 {
     @MODULE[ModuleEngineIgnitor]
-    {        
+    {
         UPGRADES
         {
             UPGRADE
             {
                 name__ = ignitionUpgrade_4
                 techRequired__ = largeElectrics
-                description__ = 
-                IgnitionsAvailable = 20                
+                description__ =
+                IgnitionsAvailable = 20
             }
         }
     }
 }
 
-    
+
 // -----------------------------
 PARTUPGRADE
 {

--- a/GameData/EngineIgnitor/MM_Configs/MM_Tantares.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Tantares.cfg
@@ -1,13 +1,28 @@
 // from forum user @woeller
 // MM Config for Tantares https://github.com/Tantares/Tantares/releases
+//Updated by Zorg 15 Oct 2019
 
-// L-858 '?????' Rocket Motor - Tantares
-@PART[Libra_Engine_1]:NEEDS[Tantares]
+// A-KYR "Dael" Thruster Block - Tantares
+@PART[Alnair_Engine_1]:NEEDS[Tantares]
 {
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 24
+		IgnitionsAvailable = 1 //This is a single use deorbit motor// 16
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 10
+	}
+}
+
+@PART[Auriga_Engine_1]:NEEDS[Tantares]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 20 //Guess
 		AutoIgnitionTemperature = 800
 		IgnitorType = Internal
 		UseUllageSimulation = true
@@ -15,20 +30,24 @@
 		ECforIgnition = 5
 	}
 }
-// V-115K "Månekanin" Departure Engine - Tantares
-@PART[Virgo_Engine_1]:NEEDS[Tantares]
+
+
+@PART[Libra_Engine_s1_1]:NEEDS[Tantares]
 {
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 24
+		IgnitionsAvailable = 24 // Astronautix suggests 2 starts for this but its a landing enigne and I'm kind and am going to leave this as is :)
 		AutoIgnitionTemperature = 800
 		IgnitorType = Internal
 		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.2  //0-1
-		ECforIgnition = 20
+		ChanceWhenUnstable = 0.7  //0-1
+		ECforIgnition = 5
 	}
 }
+
+
+
 // T-85K "Reinsdyr" Orbital Engine - Tantares
 @PART[Tantares_Engine_1]:NEEDS[Tantares]
 {
@@ -43,17 +62,75 @@
 		ECforIgnition = 20
 	}
 }
-// A-KYR "Dael" Thruster Block - Tantares
-@PART[Alnair_Engine_1]:NEEDS[Tantares]
+
+@PART[Tantares_Engine_2]:NEEDS[Tantares]
 {
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 16
+		IgnitionsAvailable = 20
 		AutoIgnitionTemperature = 800
 		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2  //0-1
-		ECforIgnition = 10
+		ECforIgnition = 20
+	}
+}
+
+@PART[vega_engine_srf_1_1]:NEEDS[Tantares]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 20
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 20
+	}
+}
+
+@PART[vega_engine_srf_1_2]:NEEDS[Tantares]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 20
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 20
+	}
+}
+
+// V-115K "Mï¿½nekanin" Departure Engine - Tantares
+@PART[Virgo_Engine_1]:NEEDS[Tantares]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 24
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 20
+	}
+}
+
+//deprecated ------------------------------//
+@PART[Libra_Engine_1]:NEEDS[Tantares]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 24
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.7  //0-1
+		ECforIgnition = 5
 	}
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_Tantares.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Tantares.cfg
@@ -13,7 +13,7 @@
 		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2  //0-1
-		ECforIgnition = 10
+		ECforIgnition = 5
 	}
 }
 
@@ -87,7 +87,7 @@
 		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2  //0-1
-		ECforIgnition = 20
+		ECforIgnition = 5
 	}
 }
 
@@ -101,7 +101,7 @@
 		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2  //0-1
-		ECforIgnition = 20
+		ECforIgnition = 5
 	}
 }
 

--- a/GameData/EngineIgnitor/MM_Configs/MM_Tantares_LV.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Tantares_LV.cfg
@@ -1,4 +1,5 @@
 // from forum user @woeller
+// Updated by Zorg 15 Oct 2019
 // MM Config for Tantares LV https://github.com/Tantares/TantaresLV/releases
 
 // A-11K Boosters Stage - Tantares LV
@@ -8,21 +9,36 @@
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 1
+		IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
 		AutoIgnitionTemperature = 500
-		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2  //0-1
 		ECforIgnition = 50
 	}
 }
+
+@PART[ALV_1_Engine_2]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 500
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 50
+	}
+}
+
 // A-22K Rocket Motor - Tantares LV
 @PART[ALV_2_Engine_1]:NEEDS[TantaresLV]
 {
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 2
+		IgnitionsAvailable = 1
 		AutoIgnitionTemperature = 800
 		IgnitorType = Internal
 		UseUllageSimulation = true
@@ -30,13 +46,14 @@
 		ECforIgnition = 20
 	}
 }
+
 // A-33K Rocket Motor - Tantares LV
 @PART[ALV_3_Engine_1]:NEEDS[TantaresLV]
 {
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 4
+		IgnitionsAvailable = 1
 		AutoIgnitionTemperature = 800
 		IgnitorType = Internal
 		UseUllageSimulation = true
@@ -44,6 +61,314 @@
 		ECforIgnition = 20
 	}
 }
+
+// Vostok Blok E
+@PART[AndromedaUS_Engine_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 20
+	}
+}
+
+//Kosmos 2I 1st stage
+@PART[chara_lv_engine_s0p5_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		IgnitorType = Internal
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 20
+	}
+}
+
+//Kosmos 2I 2nd stage
+@PART[chara_lv_engine_s0p5_2]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 20
+	}
+}
+
+@PART[corvus_lv_bare_engine_s1_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 20
+	}
+}
+
+@PART[corvus_lv_bare_engine_s1_2]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 500
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.4  //0-1
+		ECforIgnition = 20
+	}
+}
+
+@PART[corvus_lv_engine_s1_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 20
+	}
+}
+
+@PART[corvus_lv_engine_s1_2]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 500
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.4  //0-1
+		ECforIgnition = 20
+	}
+}
+
+@PART[delphini_us_engine_s1_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 50
+		AutoIgnitionTemperature = 500
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.4  //0-1
+		ECforIgnition = 20
+	}
+}
+
+//Zenit RD170
+@PART[HLV_1_Engine_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 50
+	}
+}
+
+//Zenit RD120
+@PART[HLV_2_Engine_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 500
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.4  //0-1
+		ECforIgnition = 20
+	}
+}
+
+// LV-15N "Komfyr" Rocket Motor - Tantares LV
+// Engine is to big for Launch Clamp Ignition
+@PART[LLV_A_Engine_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 50
+	}
+}
+// LT-Z18 "Sverdstav" Rocket Motor - Tantares LV
+@PART[LLV_B_Engine_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 50
+	}
+}
+// LR-ET9 "Kampï¿½ks" Rocket Motor - Tantares LV
+@PART[LLV_V_Engine_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 20
+	}
+}
+// LQ-D6L 'Dolk' Rocket Motor - Tantares LV
+@PART[LLV_G_Engine_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1 //as per RO
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 10
+	}
+}
+
+@PART[RLV_1_Engine_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 50
+	}
+}
+
+@PART[RLV_1_Engine_2]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 50
+	}
+}
+
+// LV-T15 Liquid Fuel Engine - Tantares LV
+@PART[SUS_Engine_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 7 //From RO configs //16
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.4  //0-1
+		ECforIgnition = 10
+	}
+}
+
+@PART[tantares_lv_engine_s1_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 30
+	}
+}
+
+@PART[tantares_lv_engine_s1_3,tantares_lv_engine_s1p2_3,tantares_lv_engine_s1p5_3]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		IgnitorType = Internal
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 20
+	}
+}
+
+@PART[tantares_lv_engine_s1p5_2]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2  //0-1
+		ECforIgnition = 20
+	}
+}
+
+// T-2Z3 "Camel" Upper Stage - Tantares LV
+@PART[TUS_Engine_1]:NEEDS[TantaresLV]
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 50
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.4  //0-1
+		ECforIgnition = 10
+	}
+}
+
+
+
+//------------------------------------------Deprecated engines-------------------------------------///
+
 // C-14U "Krabbe" Rocket Engine - Tantares LV
 @PART[CLV_1_Engine_1]:NEEDS[TantaresLV]
 {
@@ -69,77 +394,8 @@
 		ECforIgnition = 10
 	}
 }
-// LV-15N "Komfyr" Rocket Motor - Tantares LV
-// Engine is to big for Launch Clamp Ignition
-@PART[LLV_A_Engine_1]:NEEDS[TantaresLV]
-{
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 1
-		AutoIgnitionTemperature = 500
-		IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.4  //0-1
-		ECforIgnition = 50
-	}
-}
-// LT-Z18 "Sverdstav" Rocket Motor - Tantares LV
-@PART[LLV_B_Engine_1]:NEEDS[TantaresLV]
-{
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 1
-		AutoIgnitionTemperature = 800
-		IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.2  //0-1
-		ECforIgnition = 50
-	}
-}
-// LR-ET9 "Kampøks" Rocket Motor - Tantares LV
-@PART[LLV_V_Engine_1]:NEEDS[TantaresLV]
-{
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 4
-		AutoIgnitionTemperature = 800
-		IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.2  //0-1
-		ECforIgnition = 20
-	}
-}
-// LQ-D6L 'Dolk' Rocket Motor - Tantares LV
-@PART[LLV_G_Engine_1]:NEEDS[TantaresLV]
-{
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 4
-		AutoIgnitionTemperature = 800
-		IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.2  //0-1
-		ECforIgnition = 10
-	}
-}
-// LV-T15 Liquid Fuel Engine - Tantares LV
-@PART[SUS_Engine_1]:NEEDS[TantaresLV]
-{
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 16
-		AutoIgnitionTemperature = 800
-		IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.4  //0-1
-		ECforIgnition = 10
-	}
-}
+
+
 // T-107R 'Stor Segl' Rocket Engine - Tantares LV
 @PART[TLV_0_Engine_1]:NEEDS[TantaresLV]
 {
@@ -179,18 +435,3 @@
 		ECforIgnition = 10
 	}
 }
-// T-2Z3 "Camel" Upper Stage - Tantares LV
-@PART[TUS_Engine_1]:NEEDS[TantaresLV]
-{
-	MODULE
-	{
-		name = ModuleEngineIgnitor
-		IgnitionsAvailable = 20
-		AutoIgnitionTemperature = 800
-		IgnitorType = Internal
-		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.4  //0-1
-		ECforIgnition = 10
-	}
-}
-

--- a/GameData/EngineIgnitor/MM_Configs/MM_Tantares_LV.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Tantares_LV.cfg
@@ -130,7 +130,7 @@
 		AutoIgnitionTemperature = 500
 		IgnitorType = Internal
 		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.4  //0-1
+		ChanceWhenUnstable = 0.2  //0-1
 		ECforIgnition = 20
 	}
 }
@@ -158,7 +158,7 @@
 		AutoIgnitionTemperature = 500
 		IgnitorType = Internal
 		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.4  //0-1
+		ChanceWhenUnstable = 0.2  //0-1
 		ECforIgnition = 20
 	}
 }
@@ -172,7 +172,7 @@
 		AutoIgnitionTemperature = 500
 		IgnitorType = Internal
 		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.4  //0-1
+		ChanceWhenUnstable = 0.2  //0-1
 		ECforIgnition = 20
 	}
 }
@@ -202,7 +202,7 @@
 		AutoIgnitionTemperature = 500
 		IgnitorType = Internal
 		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.4  //0-1
+		ChanceWhenUnstable = 0.2  //0-1
 		ECforIgnition = 20
 	}
 }
@@ -303,7 +303,7 @@
 		AutoIgnitionTemperature = 800
 		IgnitorType = Internal
 		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.4  //0-1
+		ChanceWhenUnstable = 0.2  //0-1
 		ECforIgnition = 10
 	}
 }
@@ -360,7 +360,7 @@
 		AutoIgnitionTemperature = 800
 		IgnitorType = Internal
 		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.4  //0-1
+		ChanceWhenUnstable = 0.2  //0-1
 		ECforIgnition = 10
 	}
 }
@@ -390,7 +390,7 @@
 		AutoIgnitionTemperature = 800
 		IgnitorType = Internal
 		UseUllageSimulation = true
-		ChanceWhenUnstable = 0.4  //0-1
+		ChanceWhenUnstable = 0.2  //0-1
 		ECforIgnition = 10
 	}
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_USI_TechUpgrades.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_USI_TechUpgrades.cfg
@@ -3,7 +3,7 @@
 
 
 // Ignitor upgrade 4 - tier 7
-@PART[FTT_Engine_375_01]:FINAL
+@PART[FTT_Engine_375_01]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -19,7 +19,7 @@
         }
     }
 }
-@PART[KER_VTOL]:FINAL
+@PART[KER_VTOL]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -35,7 +35,7 @@
         }
     }
 }
-@PART[SR_Aerospike]:FINAL
+@PART[SR_Aerospike]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -51,7 +51,7 @@
         }
     }
 }
-@PART[MKS_SkyCrane]:FINAL
+@PART[MKS_SkyCrane]
 {
     @MODULE[ModuleEngineIgnitor]
     {        

--- a/GameData/EngineIgnitor/MM_Configs/MM_Vens_TechUpgrades.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Vens_TechUpgrades.cfg
@@ -1,6 +1,6 @@
 // ======================= Engines Ignition Upgrades =======================
 // Ignitor upgrade 1 - tier 4
-@PART[LVT15]:FINAL
+@PART[LVT15]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -19,7 +19,7 @@
         }
     }
 }
-@PART[VenLV909b]:FINAL
+@PART[VenLV909b]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -38,7 +38,7 @@
 
 
 // Ignitor upgrade 2 - tier 5
-@PART[MicroEngineB]:FINAL
+@PART[MicroEngineB]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -57,7 +57,7 @@
 
 
 // Ignitor upgrade 3 - tier 7
-@PART[Size2MedEngine]:FINAL
+@PART[Size2MedEngine]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -76,7 +76,7 @@
 
 
 // Ignitor upgrade 4 - tier 7
-@PART[liquidEngineMiniTurbo]:FINAL
+@PART[liquidEngineMiniTurbo]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -95,7 +95,7 @@
 
 
 // Ignitor upgrade 8 - tier 8
-@PART[PoodleM]:FINAL
+@PART[PoodleM]
 {
     @MODULE[ModuleEngineIgnitor]
     {        
@@ -110,7 +110,7 @@
         }
     }
 }
-@PART[size2nuclearEngine]:FINAL
+@PART[size2nuclearEngine]
 {
     @MODULE[ModuleEngineIgnitor]
     {        

--- a/GameData/EngineIgnitor/MM_Configs/MM_reDIRECT.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_reDIRECT.cfg
@@ -1,0 +1,73 @@
+// Configs for reDIRECT. Based on real world ignition limits where available. Using RO configs as main reference.
+// By Zorg
+
+@PART[DIRECT_KJ10]:NEEDS[Benjee10_sharedAssets]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+		ECforIgnition = 10
+	}
+}
+
+@PART[DIRECT_SSME_B]:NEEDS[reDIRECT]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 0
+		IgnitorType = External (Launch Clamps)
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+		ECforIgnition = 40
+	}
+}
+
+@PART[DIRECT_K2X]:NEEDS[reDIRECT]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 8
+		IgnitorType = Internal
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+		ECforIgnition = 20
+	}
+}
+
+@PART[DIRECT_KL10]:NEEDS[reDIRECT]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 15
+		IgnitorType = Internal
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+		ECforIgnition = 20
+	}
+}
+
+
+@PART[DIRECT_KL10_B]:NEEDS[reDIRECT]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+    IgnitionsAvailable = 15
+		IgnitorType = Internal
+		AutoIgnitionTemperature = 800
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+		ECforIgnition = 20
+	}
+}

--- a/GameData/EngineIgnitor/MM_Configs/MM_reDIRECT.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_reDIRECT.cfg
@@ -1,7 +1,7 @@
 // Configs for reDIRECT. Based on real world ignition limits where available. Using RO configs as main reference.
 // By Zorg
 
-@PART[DIRECT_KJ10]:NEEDS[Benjee10_sharedAssets]//
+@PART[DIRECT_KJ10]:NEEDS[Benjee10_sharedAssets]//unlimited ignitions for modern AJ10 190
 {
 	MODULE
 	{
@@ -10,7 +10,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-		ECforIgnition = 10
+		ECforIgnition = 15
 	}
 }
 
@@ -52,7 +52,7 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-		ECforIgnition = 20
+		ECforIgnition = 15
 	}
 }
 
@@ -67,6 +67,6 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-		ECforIgnition = 20
+		ECforIgnition = 15
 	}
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_reDIRECT.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_reDIRECT.cfg
@@ -6,8 +6,7 @@
 	MODULE
 	{
 		name = ModuleEngineIgnitor
-    IgnitionsAvailable = 0
-		IgnitorType = External (Launch Clamps)
+		IgnitorType = Internal Unlimited
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2

--- a/GameData/EngineIgnitor/MM_Configs/RAPIER.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/RAPIER.cfg
@@ -1,4 +1,4 @@
-@PART[RAPIER]:FINAL
+@PART[RAPIER]
 {
 	MODULE
 	{
@@ -18,4 +18,4 @@
 		// If any are, then it won't use an ignitor
 		DontUseIgnitorIfMultiModeOn = true
 	}
-} 
+}

--- a/GameData/EngineIgnitor/MM_Configs/RemoveEC_EngineIgnitor.cfg.disabled
+++ b/GameData/EngineIgnitor/MM_Configs/RemoveEC_EngineIgnitor.cfg.disabled
@@ -1,0 +1,8 @@
+//Optional patch to remove EC requirement. EC causing bugs at time this was written. Also useful as a personal preferance. Change file extension from .cfg.disabled to just .cfg to use. Can place anywhere in gamedata (such as a personal patches folder) so it wont be overwritten when EI updates.
+@PART[*]:HAS[@MODULE[ModuleEngineIgnitor]]:FINAL
+{
+  @MODULE[ModuleEngineIgnitor]
+  {
+    %ECforIgnition = 0
+  }
+}


### PR DESCRIPTION
This pull request adds fresh support for the following:

- ReDirect
- Knes
- ReStock plus
- Near Future Spacecraft
- Near Future Launch Vehicles
- Modular Launch Pads
- Fuji
- Making History

Updates stale configs and newly added parts

- Stock (revamped and renamed engines)
- Tantares
- TantaresLV
- CryoEngines

Balance and options

- Increase launch clamp external ignitor range to help with combined tank and engine monolithic stages
- Optional patch to get rid of external ignitors and make all internal (disabled by default)
- Optional patch to get rid of EC requirement. At time of PR there seems to be an EC related bug, provides another option to customise for players. (Disabled by default)

Cleanup

- remove FINAL pass from any patches that use it.
- Add NEEDS to all updated configs for faster MM patching.

