### PR TITLE
Commonwealth Rockets configs and NFLV bugfix

### DIFF
--- a/GameData/EngineIgnitor/MM_Configs/MM_CommonwealthRockets.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_CommonwealthRockets.cfg
@@ -36,6 +36,20 @@
 	}
 }
 
+//Black Knight
+@PART[black_knight_engine_s1_1]:NEEDS[CRE]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+	}
+}
+
 //Blue streak
 @PART[blue_streak_engine_s1_1]:NEEDS[CRE]//
 {

--- a/GameData/EngineIgnitor/MM_Configs/MM_CommonwealthRockets.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_CommonwealthRockets.cfg
@@ -9,7 +9,6 @@
 		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 35
 	}
 }
 @PART[black_arrow_engine_s1_2]:NEEDS[CRE]//
@@ -22,7 +21,6 @@
 		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 35
 	}
 }
 @PART[black_arrow_engine_s1_3]:NEEDS[CRE]//
@@ -35,7 +33,6 @@
 		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 35
 	}
 }
 
@@ -50,7 +47,6 @@
 		IgnitorType = Launch Clamp
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 35
 	}
 }
 
@@ -64,7 +60,6 @@
 		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 35
 	}
 }
 
@@ -78,7 +73,6 @@
 		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 35
 	}
 }
 
@@ -93,6 +87,5 @@
 		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 35
 	}
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_CommonwealthRockets.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_CommonwealthRockets.cfg
@@ -1,0 +1,98 @@
+//Black Arrow
+@PART[black_arrow_engine_s1_1]:NEEDS[CRE]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+    ECforIgnition = 35
+	}
+}
+@PART[black_arrow_engine_s1_2]:NEEDS[CRE]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+    ECforIgnition = 35
+	}
+}
+@PART[black_arrow_engine_s1_3]:NEEDS[CRE]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+    ECforIgnition = 35
+	}
+}
+
+//Blue streak
+@PART[blue_streak_engine_s1_1]:NEEDS[CRE]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 0
+		AutoIgnitionTemperature = 800
+		IgnitorType = Launch Clamp
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+    ECforIgnition = 35
+	}
+}
+
+@PART[blue_streak_engine_s1_2]:NEEDS[CRE]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+    ECforIgnition = 35
+	}
+}
+
+@PART[blue_streak_engine_s1_3]:NEEDS[CRE]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 3
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+    ECforIgnition = 35
+	}
+}
+
+//Blue Steel
+@PART[blue_steel_engine_s1_1]:NEEDS[CRE]//
+{
+	MODULE
+	{
+		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 2
+		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
+		UseUllageSimulation = true
+		ChanceWhenUnstable = 0.2
+    ECforIgnition = 35
+	}
+}

--- a/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
@@ -10,7 +10,6 @@
 		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 35
 	}
 }
 
@@ -25,7 +24,6 @@
 		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 30
 	}
 }
 
@@ -38,7 +36,6 @@
 		AutoIgnitionTemperature = 800
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 50
 	}
 }
 
@@ -52,6 +49,5 @@
 		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
-    ECforIgnition = 50
 	}
 }

--- a/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
@@ -5,7 +5,9 @@
 	MODULE
 	{
 		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1000
 		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
     ECforIgnition = 35
@@ -19,7 +21,9 @@
 	MODULE
 	{
 		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1000
 		AutoIgnitionTemperature = 800
+		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
     ECforIgnition = 30
@@ -46,8 +50,9 @@
 	MODULE
 	{
 		name = ModuleEngineIgnitor
+		IgnitionsAvailable = 1000
 		AutoIgnitionTemperature = 800
-		IgnitorType = Internal Unlimited
+		IgnitorType = Internal
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
     ECforIgnition = 50

--- a/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_NearFutureLaunchVehicles.cfg
@@ -11,7 +11,6 @@
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
     ECforIgnition = 35
-		IgnitorType = Internal
 	}
 }
 
@@ -27,7 +26,6 @@
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
     ECforIgnition = 30
-		IgnitorType = Internal
 	}
 }
 
@@ -41,7 +39,6 @@
 		UseUllageSimulation = true
 		ChanceWhenUnstable = 0.2
     ECforIgnition = 50
-		IgnitorType = Internal
 	}
 }
 


### PR DESCRIPTION
new configs for Commonwealth Rockets and sets NFLV engines with spark ignitors to 1000 instead of undefined ignitions.