### PR TITLE
Update EngineIgnitor.cs

### DIFF
--- a/Source/EngineIgnitor.cs
+++ b/Source/EngineIgnitor.cs
@@ -408,7 +408,7 @@ namespace EngineIgnitor
                     ", MultiModeEngine: " + MultiModeEngine + ", CurrentActiveMode: " + CurrentActiveMode());
                 if (!MultiModeEngine || (MultiModeEngine && !OtherEngineModeActive()) || CurrentActiveMode() == EngineIndex)
                 {
-                    if (IgnitionsRemained > 0 || IgnitionsRemained == -1)
+                    if (IgnitionsRemained > 0 || IgnitionsRemained <= -1)
                     {
                         double ec = 0;
                         if (HighLogic.CurrentGame.Parameters.CustomParams<EI>().requireECforIgnition && EnoughECforIgnition())

--- a/Source/EngineIgnitor.cs
+++ b/Source/EngineIgnitor.cs
@@ -408,7 +408,7 @@ namespace EngineIgnitor
                     ", MultiModeEngine: " + MultiModeEngine + ", CurrentActiveMode: " + CurrentActiveMode());
                 if (!MultiModeEngine || (MultiModeEngine && !OtherEngineModeActive()) || CurrentActiveMode() == EngineIndex)
                 {
-                    if (IgnitionsRemained > 0 || IgnitionsRemained <= -1)
+                    if (IgnitionsRemained > 0 || IgnitionsRemained == -1)
                     {
                         double ec = 0;
                         if (HighLogic.CurrentGame.Parameters.CustomParams<EI>().requireECforIgnition && EnoughECforIgnition())
@@ -423,7 +423,10 @@ namespace EngineIgnitor
                             }
                         }
 
-                        IgnitionsRemained--;
+                        if (IgnitionsRemained != -1)
+                        {
+                            IgnitionsRemained--;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
changed requirements for ignitions to work when ignitionsremained are negative numbers. Infinite ignition engines only work once because when they ignite, the remaining ignitions drop from -1 (infinite) to -2 (?¿), meaning they act like they no longer have any ignitions avalible. 

This is of cource a crude way to fix it, since the correct way would be too add an exception for when the engines have infinite ignitions, but my code skills are not there yet.