### PR TITLE
Enable ullage simulation for making history engines

### DIFF
--- a/GameData/EngineIgnitor/MM_Configs/MM_Stock_MakingHistory.cfg
+++ b/GameData/EngineIgnitor/MM_Configs/MM_Stock_MakingHistory.cfg
@@ -10,7 +10,7 @@
         IgnitionsAvailable = 0
         AutoIgnitionTemperature = 800
         IgnitorType = External (launch Clamp)
-	      UseUllageSimulation = false
+	      UseUllageSimulation = true
     		ChanceWhenUnstable = 0.4  //0-1
         ECforIgnition = 50
     }
@@ -24,7 +24,7 @@
         IgnitionsAvailable = 1
         AutoIgnitionTemperature = 800
         IgnitorType = Internal
-    		UseUllageSimulation = false
+    		UseUllageSimulation = true
     		ChanceWhenUnstable = 0.4  //0-1
         ECforIgnition = 15
     }
@@ -38,7 +38,7 @@
         IgnitionsAvailable = 1 //To allow for Titan III style air start
         AutoIgnitionTemperature = 800
         IgnitorType = Internal
-    		UseUllageSimulation = false
+    		UseUllageSimulation = true
     		ChanceWhenUnstable = 0.4  //0-1
         ECforIgnition = 15
     }
@@ -52,7 +52,7 @@
         IgnitionsAvailable = 3
         AutoIgnitionTemperature = 800
         IgnitorType = Internal
-    		UseUllageSimulation = false
+    		UseUllageSimulation = true
     		ChanceWhenUnstable = 0.4  //0-1
         ECforIgnition = 20
     }
@@ -66,7 +66,7 @@
         IgnitionsAvailable = 50
         AutoIgnitionTemperature = 800
         IgnitorType = Internal
-    		UseUllageSimulation = false
+    		UseUllageSimulation = true
     		ChanceWhenUnstable = 0.4  //0-1
         ECforIgnition = 15
     }
@@ -80,7 +80,7 @@
         IgnitionsAvailable = 0
         AutoIgnitionTemperature = 800
         IgnitorType = External (launch Clamp)
-	      UseUllageSimulation = false
+	      UseUllageSimulation = true
     		ChanceWhenUnstable = 0.4  //0-1
         ECforIgnition = 30
     }
@@ -94,7 +94,7 @@
         IgnitionsAvailable = 18
         AutoIgnitionTemperature = 800
         IgnitorType = External (launch Clamp)
-	      UseUllageSimulation = false
+	      UseUllageSimulation = true
     		ChanceWhenUnstable = 0.4  //0-1
         ECforIgnition = 10
     }


### PR DESCRIPTION
Historical examples that engines are based on required ullage burns.